### PR TITLE
avoid repeating import of userTypes

### DIFF
--- a/src/generateModelFile.js
+++ b/src/generateModelFile.js
@@ -36,10 +36,10 @@ const generateModelFile = (
   if (referencedIdTypes.length) {
     lines.push('');
   }
-  const appliedUserTypes = map(
+  const appliedUserTypes = uniq(map(
     (p) => p.type,
     filter((p) => userTypes.indexOf(p.type) !== -1, tableOrView.columns)
-  );
+  ));
   forEach((importedType) => {
     lines.push(`import ${pc(importedType)} from './${fc(importedType)}';`);
   }, appliedUserTypes);


### PR DESCRIPTION
Hello,
Nice project, I have worked on something similar but it's very unmaintained (and slow!), so I hope you don't mind if I provide some feedback on yours!

First is a simple fix, to avoid duplicate import definitions:

```
import IdDocumentType from './id-document-type';
import IdDocumentType from './id-document-type';
```

The fix is just a matter of applying an `uniq` to the `appliedUserTypes`
