### PR TITLE
Add configurable logger

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -61,3 +61,4 @@ typings/
 .next
 
 build
+.DS_Store

--- a/src/cli.js
+++ b/src/cli.js
@@ -3,6 +3,7 @@ import chalk from 'chalk';
 // @ts-ignore
 import optionator from 'optionator';
 import processDatabase from './processDatabase';
+import { logger } from './logger';
 // @ts-ignore
 const { version } = require('../package.json');
 
@@ -38,7 +39,7 @@ async function main() {
   try {
     options = o.parseArgv(process.argv);
   } catch (error) {
-    console.error(error.message);
+    logger.error(error.message);
     process.exit(1);
   }
 
@@ -52,15 +53,21 @@ async function main() {
     process.exit(0);
   }
 
-  console.log(`${chalk.greenBright('Kanel')}`);
   const configFile = path.join(process.cwd(), options.config || '.kanelrc.js');
   const config = require(configFile);
+
+  if (config.logLevel !== undefined) {
+    logger({ level: config.logLevel });
+  }
+
+  logger.log(chalk.greenBright('Kanel'));
+  logger.quiet`${chalk.greenBright('Kanel')}: Creating psql types`;
 
   try {
     const exitCode = await processDatabase(config);
     process.exit(exitCode);
   } catch (error) {
-    console.error(error);
+    logger.error(error);
     process.exit(1);
   }
 }

--- a/src/generateFile.js
+++ b/src/generateFile.js
@@ -1,10 +1,11 @@
 import os from 'os';
 import path from 'path';
 import fs from 'fs';
+import { logger } from './logger';
 
 const generateFile = ({ fullPath, lines }) => {
   const relativePath = path.relative(process.cwd(), fullPath);
-  console.log(` - ${relativePath}`);
+  logger.log(` - ${relativePath}`);
   const allLines = [
     "// Automatically generated. Don't change this file manually.",
     '',

--- a/src/logger.js
+++ b/src/logger.js
@@ -1,0 +1,52 @@
+const LEVELS = {
+  silent: 0,
+  error: 1,
+  warn: 2,
+  quiet: 3,
+  log: 4,
+};
+
+const options = {
+  level: LEVELS.log,
+};
+
+function createLogger(level, method, exact = false) {
+  return function (first, ...rest) {
+    if (level > options.level || (exact && options.level !== level)) return;
+    if (first.raw) {
+      console[method](String.raw(first, ...rest));
+    } else {
+      console[method](first, ...rest);
+    }
+  };
+}
+
+export const log = createLogger(LEVELS.log, 'log', true);
+export const quiet = createLogger(LEVELS.quiet, 'log', true);
+export const warn = createLogger(LEVELS.warn, 'warn');
+export const error = createLogger(LEVELS.error, 'error');
+
+/**
+ * @param {{ level: keyof LEVELS | 0 | 1 | 2 | 3 }} config
+ *  */
+export function logger(config) {
+  switch (typeof config.level) {
+    case 'string': {
+      options.level = LEVELS[config.level.toLowerCase()];
+      break;
+    }
+    case 'number': {
+      options.level = config.level;
+      break;
+    }
+    case 'boolean': {
+      options.level = config.level ? LEVELS.log : LEVELS.silent;
+      break;
+    }
+  }
+}
+
+logger.log = log;
+logger.warn = warn;
+logger.error = error;
+logger.quiet = quiet;

--- a/src/processDatabase.js
+++ b/src/processDatabase.js
@@ -8,6 +8,7 @@ import { recase } from '@kristiandupont/recase';
 import generateModelFile from './generateModelFile';
 import generateTypeFile from './generateTypeFile';
 import generateIndexFile from './generateIndexFile';
+import { logger } from './logger';
 
 const defaultTypeMap = {
   int2: 'number',
@@ -37,7 +38,7 @@ const processDatabase = async ({
 }) => {
   const typeMap = { ...defaultTypeMap, ...customTypeMap };
 
-  console.log(
+  logger.log(
     `Connecting to ${chalk.greenBright(connection.database)} on ${
       connection.host
     }`
@@ -50,7 +51,7 @@ const processDatabase = async ({
 
   for (const schema of schemas) {
     if (preDeleteModelFolder) {
-      console.log(` - Clearing old files in ${schema.modelFolder}`);
+      logger.log(` - Clearing old files in ${schema.modelFolder}`);
       await rmfr(schema.modelFolder, { glob: true });
     }
     if (!fs.existsSync(schema.modelFolder)) {


### PR DESCRIPTION
I'm using kanel at the beginning of my dev script with `kanel && npm run start` and have found that the logs are a bit noisy. This pr adds a config option called `logLevel` to .kanelrc.

The options it accepts are 
- 0 | `silent` = No logs
- 1 | `error` = Logs created with logger.error
- 2 | `warning` = Logs created with logger.warn and logger.error
- 3 | `quiet` = Logs created with logger.quiet, logger.warn and logger.err
- 4 | `log`= All logs

The default logLevel is 4 until it is configured in .kanelrc