### PR TITLE
Change the ID types property so intellisense doesnt suggest it

### DIFF
--- a/src/generateModelFile.js
+++ b/src/generateModelFile.js
@@ -97,7 +97,7 @@ const generateModelFile = (
     const innerType =
       tags.type || typeMap[type] || nominators.typeNominator(type);
     lines.push(
-      `export type ${makeIdName(model.name)} = ${innerType} & { __flavor?: '${
+      `export type ${makeIdName(model.name)} = ${innerType} & { " __flavor"?: '${
         model.name
       }' };`
     );

--- a/src/generateModelFile.js
+++ b/src/generateModelFile.js
@@ -97,9 +97,9 @@ const generateModelFile = (
     const innerType =
       tags.type || typeMap[type] || nominators.typeNominator(type);
     lines.push(
-      `export type ${makeIdName(model.name)} = ${innerType} & { " __flavor"?: '${
+      `export type ${makeIdName(
         model.name
-      }' };`
+      )} = ${innerType} & { " __flavor"?: '${model.name}' };`
     );
     lines.push('');
   }


### PR DESCRIPTION
Just a little ergonomic change, by putting a space at the start of the property name your IDE wont suggest it when you type `myUserId.`