### PR TITLE
fix link to example models folder

### DIFF
--- a/example/README.md
+++ b/example/README.md
@@ -1,6 +1,6 @@
 # Example
 
-The files in the [/models](/models) folder are generated from the configuration file in this folder.
+The files in the [/models](/example/models) folder are generated from the configuration file in this folder.
 They are built from an instance of the [Sample Database](https://www.postgresqltutorial.com/postgresql-sample-database/) from www.postgresqltutorial.com.
 
 ![Database diagram](https://sp.postgresqltutorial.com/wp-content/uploads/2018/03/dvd-rental-sample-database-diagram.png)


### PR DESCRIPTION
The `/models` link appears to be an "absolute" path, and gets redirected to `https://github.com/kristiandupont/kanel/blob/master/models`