### PR TITLE
Fix export of the interfaces in the index file

### DIFF
--- a/src/generateIndexFile.js
+++ b/src/generateIndexFile.js
@@ -117,7 +117,7 @@ function generateIndexFile(models, userTypes, nominators) {
     ),
     '}',
     '',
-    'export {',
+    'export type {',
     ...map(exportLine, models),
     ...map((t) => `  ${nominators.typeNominator(t)},`, userTypes),
     '',


### PR DESCRIPTION
When the typescript [`isolatedModules` flag](https://www.typescriptlang.org/tsconfig#isolatedModules) is set to true in `tsconfig.json` file, the following error occurs on the whole exported object and the code is not compilable by Babel:
```
Re-exporting a type when the '--isolatedModules' flag is provided requires using 'export type'
```

Since TS 3.8+ it is able to use [type-only imports and exports](https://www.typescriptlang.org/docs/handbook/release-notes/typescript-3-8.html#-type-only-imports-and-export) with that flag turned on.