### PR TITLE
Support composite types

### DIFF
--- a/README.md
+++ b/README.md
@@ -99,11 +99,11 @@ A function (`(givenName: string, modelName: string) => string`) that converts a 
 
 `typeHooks`
 
-Like the `modelHooks` property, this property can specify a number of hooks to attach to generation of type (enum) files. They have the same signature, only the `src` parameter is a [type](https://github.com/kristiandupont/extract-pg-schema#type) object.
+Like the `modelHooks` property, this property can specify a number of hooks to attach to generation of type (enum or composite) files. They have the same signature, only the `src` parameter is a [type](https://github.com/kristiandupont/extract-pg-schema#type) object.
 
 `typeNominator`
 
-A function (`(modelName: string) => string`) that converts a custom postgres type (enum) name into a type name.
+A function (`(modelName: string) => string`) that converts a custom postgres type (enum or composite) name into a type name.
 
 `fileNominator`
 
@@ -130,7 +130,7 @@ An array of tables and views to ignore. Use this if there are things in your dat
 
 To see an example of the result, check out the [/example](example) folder. It uses the [Sample Database](https://www.postgresqltutorial.com/postgresql-sample-database/) from www.postgresqltutorial.com.
 
-Kanel will scan tables, views and enum types. It will generate a model type for each table and view. Additionally, it will create an _initializer_ type for tables that aren't tagged `@fixed` in the comment. Initializer types
+Kanel will scan tables, views, composite and enum types. It will generate a model type for each table and view. Additionally, it will create an _initializer_ type for tables that aren't tagged `@fixed` in the comment. Initializer types
 represent the requirements for creating a new row in the table. Columns that are nullable or have default values are considered optional.
 
 Documentation is extracted from postgres comments on your tables, columns etc., as jsdoc.

--- a/src/Config.ts
+++ b/src/Config.ts
@@ -1,6 +1,6 @@
 import { Type } from 'extract-pg-schema';
 import { ConnectionConfig } from 'pg';
-import { Model } from './generateModelFile';
+import { Model } from './Model';
 
 export type TypeMap = { [index: string]: string };
 
@@ -11,7 +11,7 @@ export type Hook<T> = (lines: string[], src?: T) => string[];
 // (i.e. modelNominator or typeNominator), and make sure that those
 // are the ones passed into the secondary nominators that create
 // things like initializer and file names.
-type GivenName = string & { __brand: 'given-name' };
+export type GivenName = string & { __brand: 'given-name' };
 
 // Pass-through for defaults.
 export const nameIdentity = (name: string): GivenName => name as GivenName;

--- a/src/Model.ts
+++ b/src/Model.ts
@@ -1,0 +1,15 @@
+import { CompositeType, TableOrView } from 'extract-pg-schema';
+
+export type TableModel = TableOrView & {
+  type: 'table';
+};
+
+export type ViewModel = TableOrView & {
+  type: 'view';
+};
+
+export type CompositeTypeModel = CompositeType & {
+  type: 'composite';
+};
+
+export type Model = TableModel | ViewModel | CompositeTypeModel;

--- a/src/generateCompositeTypeFile.ts
+++ b/src/generateCompositeTypeFile.ts
@@ -1,0 +1,135 @@
+import { Attribute, CompositeType } from 'extract-pg-schema';
+import { forEach, map, filter, uniq } from 'ramda';
+import { GivenName, Nominators, TypeMap } from './Config';
+import generateInterface from './generateInterface';
+import ImportGenerator from './importGenerator';
+import path from 'path';
+
+const generateCompositeTypeFile = (
+  compositeType: CompositeType,
+  {
+    typeMap,
+    userTypes,
+    tableOrViewTypes,
+    schemaName,
+    nominators,
+    externalTypesFolder,
+    schemaFolderMap,
+  }: {
+    typeMap: TypeMap;
+    userTypes: string[];
+    tableOrViewTypes: string[];
+    schemaName: string;
+    nominators: Nominators;
+    externalTypesFolder?: string;
+    schemaFolderMap: {
+      [schemaName: string]: string;
+    };
+  }
+): string[] => {
+  const fileNominator = nominators.fileNominator;
+
+  const lines = [];
+  const { comment, tags } = compositeType;
+
+  const importGenerator = new ImportGenerator(schemaFolderMap[schemaName]);
+  const appliedUserTypes = uniq(
+    map(
+      (p: Attribute) => p.type,
+      filter((p) => userTypes.indexOf(p.type) !== -1, compositeType.attributes)
+    )
+  );
+  appliedUserTypes.forEach((t) => {
+    const givenName = nominators.typeNominator(t);
+    importGenerator.addImport(
+      givenName,
+      true,
+      path.join(schemaFolderMap[schemaName], fileNominator(givenName, t))
+    );
+  });
+
+  // Handle tables and views used as attribute types.
+  const appliedTableOrViewTypes = uniq(
+    map(
+      (p: Attribute) => p.type,
+      filter(
+        (p) => tableOrViewTypes.indexOf(p.type) !== -1,
+        compositeType.attributes
+      )
+    )
+  );
+  appliedTableOrViewTypes.forEach((t) => {
+    const givenName = nominators.modelNominator(t);
+    importGenerator.addImport(
+      givenName,
+      true,
+      path.join(schemaFolderMap[schemaName], fileNominator(givenName, t))
+    );
+  });
+
+  const overriddenTypes = map(
+    (p: Attribute) => p.tags.type,
+    filter((p) => !!p.tags.type, compositeType.attributes)
+  );
+  forEach((importedType) => {
+    const givenName = importedType as GivenName; // We expect people to have used proper casing in their comments
+    importGenerator.addImport(
+      givenName,
+      true,
+      path.join(
+        externalTypesFolder,
+        fileNominator(givenName, importedType as string)
+      )
+    );
+  }, overriddenTypes);
+
+  const importLines = importGenerator.generateLines();
+  lines.push(...importLines);
+
+  if (importLines.length) {
+    lines.push('');
+  }
+
+  const properties = compositeType.attributes.map((a) => {
+    /** @type {string} */
+    // @ts-ignore
+    let rawType = a.tags.type || typeMap[a.type];
+    if (!rawType) {
+      console.warn(`Unrecognized type: '${a.type}'`);
+      if (tableOrViewTypes.indexOf(a.type) !== -1) {
+        rawType = nominators.modelNominator(a.type);
+      } else {
+        rawType = nominators.typeNominator(a.type);
+      }
+    }
+    const typeName = (a.nullable ? `${rawType} | null` : rawType) as string;
+    const modelAttributes = {
+      commentLines: a.comment ? [a.comment] : [],
+      optional: false,
+    };
+
+    return {
+      name: nominators.propertyNominator(a.name, compositeType),
+      optional: false,
+      typeName,
+      modelAttributes,
+    };
+  });
+
+  const givenName = nominators.typeNominator(compositeType.name);
+
+  const interfaceLines = generateInterface({
+    name: givenName,
+    properties: properties.map(({ modelAttributes, ...props }) => ({
+      ...props,
+      ...modelAttributes,
+    })),
+    comment,
+    exportAsDefault: true,
+  });
+  lines.push(...interfaceLines);
+
+  return lines;
+};
+
+export default generateCompositeTypeFile;

--- a/src/generateIndexFile.js
+++ b/src/generateIndexFile.js
@@ -12,7 +12,7 @@ function generateIndexFile(models, userTypes, nominators) {
   // const pc = recase(casings.sourceCasing, casings.propertyCasing);
   // const fc = recase(casings.sourceCasing, casings.filenameCasing);
 
-  const isFixed = (m) => m.isView || m.tags['fixed'];
+  const isFixed = (m) => m.type !== 'table' || m.tags['fixed'];
 
   const hasIdentifier = (m) =>
     filter((c) => c.isPrimary, m.columns).length === 1;

--- a/src/generateModelFile.js
+++ b/src/generateModelFile.js
@@ -6,13 +6,14 @@ import path from 'path';
 /**
  * @typedef { import('extract-pg-schema').TableOrView } TableOrView
  * @typedef { import('extract-pg-schema').Type } Type
- * @typedef { TableOrView & { isView: boolean } } Model
+ * @typedef { import('./Model').TableModel } TableModel
+ * @typedef { import('./Model').ViewModel } ViewModel
  * @typedef { import('./Config').Nominators } Nominators
  * @typedef {import('./Config').TypeMap} TypeMap
  */
 
 /**
- * @param {Model} model
+ * @param {TableModel | ViewModel} model
  * @param {{ typeMap: TypeMap, userTypes: (string | any)[], schemaName: string, nominators: Nominators, externalTypesFolder?: string, schemaFolderMap: {[schemaName: string]: string}, makeIdType: (innerType: string, modelName: string) => string }} p1
  * @returns {string[]}
  */
@@ -168,7 +169,7 @@ const generateModelFile = (
   });
   lines.push(...interfaceLines);
 
-  const generateInitializer = !tags['fixed'] && !model.isView;
+  const generateInitializer = !tags['fixed'] && model.type === 'table';
   if (generateInitializer) {
     lines.push('');
     const initializerInterfaceLines = generateInterface({

--- a/src/generateTypeFile.js
+++ b/src/generateTypeFile.js
@@ -1,5 +1,5 @@
 /**
- * @param {import('extract-pg-schema').Type} type
+ * @param {import('extract-pg-schema').EnumType} type
  * @param {(typeName: string) => string} nominator
  * @returns {string[]}
  */

--- a/src/getSupportedTypes.ts
+++ b/src/getSupportedTypes.ts
@@ -1,0 +1,29 @@
+import { CompositeType, EnumType, Type } from 'extract-pg-schema';
+
+const getSupportedTypes = (
+  types: Type[]
+): {
+  enumTypes: EnumType[];
+  compositeTypes: CompositeType[];
+} => {
+  const enumTypes: EnumType[] = [];
+  const compositeTypes: CompositeType[] = [];
+
+  for (const type of types) {
+    switch (type.type) {
+      case 'composite':
+        compositeTypes.push(type);
+        break;
+      case 'enum':
+        enumTypes.push(type);
+        break;
+    }
+  }
+
+  return {
+    enumTypes,
+    compositeTypes,
+  };
+};
+
+export default getSupportedTypes;


### PR DESCRIPTION
Addresses #123.

If accepted as-is both this PR and the extract-pg-schema PR contain breaking changes for TS users with typed nominators. Anyone relying on more than the model name for `propertyNominator` may have a JS breaking change to address.

Depends on PR [extract-pg-schema#95](https://github.com/kristiandupont/extract-pg-schema/pull/95) from extract-pg-schema.