### PR TITLE
Fix error propagation on config parsing

### DIFF
--- a/packages/kanel/src/cli.js
+++ b/packages/kanel/src/cli.js
@@ -2,6 +2,7 @@ import chalk from 'chalk';
 import cliProgress from 'cli-progress';
 import optionator from 'optionator';
 import path from 'path';
+import fs from 'fs';
 
 import processDatabase from './processDatabase';
 // @ts-ignore
@@ -71,17 +72,15 @@ async function main() {
 
   /** @type {import('./config-types').Config} */
   let config;
-  try {
-    const configFile = path.join(
-      process.cwd(),
-      options.config || '.kanelrc.js'
-    );
-    config = require(configFile);
-  } catch (error) {
-    if (options.config) {
+  const configFile = path.join(process.cwd(), options.config || '.kanelrc.js');
+  if (fs.existsSync(configFile)) {
+    try {
+      config = require(configFile);
+    } catch (error) {
       console.error('Could not open ' + options.config, ': ', error);
       process.exit(1);
     }
+  } else {
     config = { connection: 'Missing connection string' };
   }
 


### PR DESCRIPTION
Error is not reported when using default config path `.kanelrc.js` and the module contains an error. In this case, the whole config is silently replaced by `{ connection: 'Missing connection string' }` (probably to have a fallback when there is no config needed and we loaded missing file).

This leads to extremely confusing behavior if there is a runtime error in the config (e.g. unresolved import path as in my case), since your config 1) is loaded and 2) contains `outputPath`, Kanel CLI reports:

```
Kanel
No output path specified, in config file or command line
```
Exactly becase of the fallback.

I updated the error handling so that
1) Load error is always showed to the user, to make sure the confusing
   default is never set silently
2) Kept the module require only when the file exists (to still keep to
   option of having no config file at all and supply all args via ARGS

Note: I think it would be better to drop the default altogether, and have the execution die later on on missing connection, but I am new to the project so I did least ammount of changes while fixing the bug.