### PR TITLE
fix: allow for non-primitives as primary key (enums)

### DIFF
--- a/packages/kanel/src/default-metadata-generators.ts
+++ b/packages/kanel/src/default-metadata-generators.ts
@@ -73,12 +73,21 @@ export const defaultGenerateIdentifierType: GenerateIdentifierType = (
     // Explicitly disable identifier resolution so we get the actual inner type here
     generateIdentifierType: undefined,
   });
+  const imports = [];
 
+  let type = innerType;
+  if (typeof innerType === 'object') {
+    // Handle non-primitives
+    type = innerType.name;
+    imports.push(innerType);
+  }
+  
   return {
     declarationType: 'typeDeclaration',
     name,
     exportAs: 'named',
-    typeDefinition: [`${innerType} & { __brand: '${name}' }`],
+    typeDefinition: [`${type} & { __brand: '${name}' }`],
+    typeImports: imports,
     comment: [`Identifier type for ${details.schemaName}.${details.name}`],
   };
 };

--- a/packages/kanel/src/default-metadata-generators.ts
+++ b/packages/kanel/src/default-metadata-generators.ts
@@ -81,7 +81,7 @@ export const defaultGenerateIdentifierType: GenerateIdentifierType = (
     type = innerType.name;
     imports.push(innerType);
   }
-  
+
   return {
     declarationType: 'typeDeclaration',
     name,


### PR DESCRIPTION
This isn't critical since you can override the `generateIdentifierType` via the config, but the default implementation fails if a non-primitive type (enums) is used in a compound primary key.