### PR TITLE
generateIndexFile always exporting enum

### DIFF
--- a/packages/kanel/src/generators/makeEnumsGenerator.ts
+++ b/packages/kanel/src/generators/makeEnumsGenerator.ts
@@ -39,11 +39,11 @@ const makeMapper =
         `export { ${name} };`,
         '',
         `type UnionType = keyof typeof ${name};`,
-        `export default ${style === 'enum' ? name : "UnionType"};`
+        `export default ${style === 'enum' ? name : 'UnionType'};`
       ],
     };
 
-    return { path, declaration }
+    return { path, declaration };
   };
 
 const makeEnumsGenerator =

--- a/packages/kanel/src/generators/makeEnumsGenerator.ts
+++ b/packages/kanel/src/generators/makeEnumsGenerator.ts
@@ -2,10 +2,7 @@ import { EnumDetails, Schema } from 'extract-pg-schema';
 import { tryParse } from 'tagged-comment-parser';
 
 import { InstantiatedConfig } from '../config-types';
-import {
-  Declaration,
-  GenericDeclaration,
-} from '../declaration-types';
+import { Declaration, GenericDeclaration } from '../declaration-types';
 import escapeName from '../escapeName';
 import Output, { Path } from '../Output';
 
@@ -41,17 +38,12 @@ const makeMapper =
         '',
         `export { ${name} };`,
         '',
-        ...style === 'enum'
-          ? [ `export default ${name};` ]
-          : [
-              `type UnionType = keyof typeof ${name};`,
-              `export default UnionType;`,
-            ]
+        `type UnionType = keyof typeof ${name};`,
+        `export default ${style === 'enum' ? name : "UnionType"};`
       ],
     };
 
     return { path, declaration }
-
   };
 
 const makeEnumsGenerator =

--- a/packages/kanel/src/generators/makeEnumsGenerator.ts
+++ b/packages/kanel/src/generators/makeEnumsGenerator.ts
@@ -5,7 +5,6 @@ import { InstantiatedConfig } from '../config-types';
 import {
   Declaration,
   GenericDeclaration,
-  TypeDeclaration,
 } from '../declaration-types';
 import escapeName from '../escapeName';
 import Output, { Path } from '../Output';
@@ -30,34 +29,29 @@ const makeMapper =
       config
     );
 
-    if (style === 'type') {
-      const declaration: TypeDeclaration = {
-        declarationType: 'typeDeclaration',
-        name,
-        comment,
-        exportAs: 'default',
-        typeDefinition: [
-          '', // Start definition on new line
-          ...enumDetails.values.map((value) => `| '${value}'`),
-        ],
-      };
-      return { path, declaration };
-    } else {
-      const declaration: GenericDeclaration = {
-        declarationType: 'generic',
-        comment,
-        lines: [
-          `enum ${name} {`,
-          ...enumDetails.values.map(
-            (value) => `  ${escapeName(value)} = '${value}',`
-          ),
-          '};',
-          '',
-          `export default ${name};`,
-        ],
-      };
-      return { path, declaration };
-    }
+    const declaration: GenericDeclaration = {
+      declarationType: 'generic',
+      comment,
+      lines: [
+        `enum ${name} {`,
+        ...enumDetails.values.map(
+          (value) => `  ${escapeName(value)} = '${value}',`
+        ),
+        '};',
+        '',
+        `export { ${name} };`,
+        '',
+        ...style === 'enum'
+          ? [ `export default ${name};` ]
+          : [
+              `type UnionType = keyof typeof ${name};`,
+              `export default UnionType;`,
+            ]
+      ],
+    };
+
+    return { path, declaration }
+
   };
 
 const makeEnumsGenerator =

--- a/packages/kanel/src/generators/makeEnumsGenerator.ts
+++ b/packages/kanel/src/generators/makeEnumsGenerator.ts
@@ -39,7 +39,7 @@ const makeMapper =
         `export { ${name} };`,
         '',
         `type UnionType = keyof typeof ${name};`,
-        `export default ${style === 'enum' ? name : 'UnionType'};`
+        `export default ${style === 'enum' ? name : 'UnionType'};`,
       ],
     };
 

--- a/packages/kanel/src/hooks/generateIndexFile.ts
+++ b/packages/kanel/src/hooks/generateIndexFile.ts
@@ -65,7 +65,8 @@ const generateIndexFile: PreRenderHook = (outputAcc, instantiatedConfig) => {
         ', '
       )} } from './${importPath}';`;
     } else if (d.kind === 'enum') {
-      result = `export { default as ${selectorName} } from './${importPath}';`;
+      const prefix = instantiatedConfig.enumStyle === 'type' ? 'type ' : ''
+      result = `export ${ prefix }{ default as ${selectorName} } from './${importPath}';`;
     } else {
       result = `export type { default as ${selectorName} } from './${importPath}';`;
     }

--- a/packages/kanel/src/hooks/generateIndexFile.ts
+++ b/packages/kanel/src/hooks/generateIndexFile.ts
@@ -65,8 +65,7 @@ const generateIndexFile: PreRenderHook = (outputAcc, instantiatedConfig) => {
         ', '
       )} } from './${importPath}';`;
     } else if (d.kind === 'enum') {
-      const prefix = instantiatedConfig.enumStyle === 'type' ? 'type ' : '';
-      result = `export ${prefix}{ default as ${selectorName} } from './${importPath}';`;
+      result = `export { ${d.name} as ${selectorName} } from './${importPath}';`;
     } else {
       result = `export type { default as ${selectorName} } from './${importPath}';`;
     }

--- a/packages/kanel/src/hooks/generateIndexFile.ts
+++ b/packages/kanel/src/hooks/generateIndexFile.ts
@@ -65,8 +65,8 @@ const generateIndexFile: PreRenderHook = (outputAcc, instantiatedConfig) => {
         ', '
       )} } from './${importPath}';`;
     } else if (d.kind === 'enum') {
-      const prefix = instantiatedConfig.enumStyle === 'type' ? 'type ' : ''
-      result = `export ${ prefix }{ default as ${selectorName} } from './${importPath}';`;
+      const prefix = instantiatedConfig.enumStyle === 'type' ? 'type ' : '';
+      result = `export ${prefix}{ default as ${selectorName} } from './${importPath}';`;
     } else {
       result = `export type { default as ${selectorName} } from './${importPath}';`;
     }


### PR DESCRIPTION

enumStyle option would be ignored on generateIndexFile,
used only to determine default export for type declarations.

whatever enumStyle is set to, generateIndexFile always exporting enum.

enums are much more practical and can be easily converted to union types, can be used at runtime etc.
