### PR TITLE
switch default type of int8, float8 and numeric to typescript type number

### DIFF
--- a/packages/kanel/src/defaultTypeMap.ts
+++ b/packages/kanel/src/defaultTypeMap.ts
@@ -3,10 +3,10 @@ import TypeMap from './TypeMap';
 const defaultTypeMap: TypeMap = {
   'pg_catalog.int2': 'number',
   'pg_catalog.int4': 'number',
-  'pg_catalog.int8': 'string',
+  'pg_catalog.int8': 'number',
   'pg_catalog.float4': 'number',
-  'pg_catalog.float8': 'string',
-  'pg_catalog.numeric': 'string',
+  'pg_catalog.float8': 'number',
+  'pg_catalog.numeric': 'number',
   'pg_catalog.bool': 'boolean',
   'pg_catalog.json': 'unknown',
   'pg_catalog.jsonb': 'unknown',


### PR DESCRIPTION
Thank you for this project! So far it is super helpful.

I noiticed that the default type of my `bigint/int8` columns were generated as `string` types.
I would expect the default mapping to be of type `number`.

I checked the `defaulttypemap` and found this to be true also for `float8` and `numeric` types.
Is there a specific reason for this default mapping?

This PR would simply adapt these types to be mapped to `number`