### PR TITLE
Extend logic for View resolution and consideration of Public schema

### DIFF
--- a/package.json
+++ b/package.json
@@ -25,6 +25,7 @@
     "start-example-db": "docker run -d --name dvd-rental -p 54321:5432 kristiandupont/dvdrental-image",
     "stop-example-db": "docker stop dvd-rental",
     "lint": "eslint . -f visualstudio --report-unused-disable-directives --ext .js,.ts",
+    "lint:fix": "eslint . -f visualstudio --report-unused-disable-directives --ext .js,.ts --fix",
     "docs:dev": "vitepress dev docs-src",
     "docs:build": "vitepress build docs-src"
   },


### PR DESCRIPTION
PSQL has a fallback mechanism on `public` schema by default which causes an issue with type resolution of Views in a separate schema. You can end up in a case where it tries to look for a View in your source schema, and never fallback on the public.

Separately, PSQL's extensive typing means a "composite" type can come from an explicit type, but also a table, a view, a materialized view, and again from `public` schema as well. So it's important to look in all these.

Without this, PSQL can end up in an infinite loop as it tries to find a type, but it can't so it tries again.

It took me a while to create this PR, so I forgot some of the context 😅 I can't tell if the `public` fallback is a decent one, but it is what PSQL itself does, so it's probably fine.

Refers to #402 (and potentially closes it)