### PR TITLE
Consider dimensions when generating zod schemas

### DIFF
--- a/packages/kanel-zod/src/generateProperties.ts
+++ b/packages/kanel-zod/src/generateProperties.ts
@@ -55,8 +55,10 @@ const generateProperties = <D extends CompositeDetails>(
         const x = config.zodTypeMap[p.type.fullName];
         if (typeof x === 'string') {
           zodType = x;
-          for (let i = p.dimensions || 0; i > 0; i--) {
-            zodType = `${zodType}.array()`;
+          if ('dimensions' in p) {
+            for (let i = p.dimensions || 0; i > 0; i--) {
+              zodType = `${zodType}.array()`;
+            }
           }
         } else {
           zodType = x.name;

--- a/packages/kanel-zod/src/generateProperties.ts
+++ b/packages/kanel-zod/src/generateProperties.ts
@@ -55,6 +55,9 @@ const generateProperties = <D extends CompositeDetails>(
         const x = config.zodTypeMap[p.type.fullName];
         if (typeof x === 'string') {
           zodType = x;
+          for (let i = p.dimensions || 0; i > 0; i--) {
+            zodType = `${zodType}.array()`;
+          }
         } else {
           zodType = x.name;
           typeImports.push(...x.typeImports);


### PR DESCRIPTION
Add calls to append `.array()` for each dimension for types in the configured map