### PR TITLE
Add support for both GENERATED ALWAYS and GENERATED BY DEFAULT

### DIFF
--- a/packages/kanel-kysely/src/processFile.ts
+++ b/packages/kanel-kysely/src/processFile.ts
@@ -100,18 +100,21 @@ const processFile = (
           }
 
           let initializerType = 'never';
-          if (canInitialize) {
+          if (canInitialize && column.generated !== 'ALWAYS') {
             if (baseType === 'Date') {
               baseType += ' | string';
             }
             initializerType =
-              column.isNullable || column.defaultValue || column.isIdentity
+              column.isNullable ||
+              column.defaultValue ||
+              column.isIdentity ||
+              column.generated === 'BY DEFAULT'
                 ? `${baseType} | null`
                 : baseType;
           }
 
           let mutatorType = 'never';
-          if (canMutate) {
+          if (canMutate && column.generated !== 'ALWAYS') {
             mutatorType = `${baseType} | null`;
           }
 

--- a/packages/kanel/src/generators/generateProperties.ts
+++ b/packages/kanel/src/generators/generateProperties.ts
@@ -26,8 +26,9 @@ const generateProperties = <D extends CompositeDetails>(
     ? R.sort(config.propertySortFunction, ps as any)
     : ps;
 
-  const result: InterfacePropertyDeclaration[] = sortedPs.map(
-    (p: CompositeProperty): InterfacePropertyDeclaration => {
+  const result: InterfacePropertyDeclaration[] = sortedPs
+    .filter((p) => generateFor === 'selector' || p.generated !== 'ALWAYS')
+    .map((p: CompositeProperty): InterfacePropertyDeclaration => {
       // If this is a (materialized or not) view column, we need to check
       // the source table to see if the column is nullable.
       if ((p as ViewColumn | MaterializedViewColumn).source) {
@@ -58,7 +59,10 @@ const generateProperties = <D extends CompositeDetails>(
       } = config.getPropertyMetadata(p, details, generateFor, config);
 
       const canBeOptional: boolean =
-        p.isNullable || p.defaultValue || p.isIdentity;
+        p.isNullable ||
+        p.defaultValue ||
+        p.isIdentity ||
+        p.generated === 'BY DEFAULT';
 
       const t = typeOverride ?? resolveType(p, details, config);
 
@@ -107,8 +111,7 @@ const generateProperties = <D extends CompositeDetails>(
         typeName,
         typeImports,
       };
-    },
-  );
+    });
   return result;
 };
 


### PR DESCRIPTION
This PR adds support for `GENERATED ALWAYS` and `GENERATED BY DEFAULT` in kanel and kanel-kysely. This fixes #450.

For kanel this PR ensures columns marked as `GENERATED ALWAYS` do not show up in mutator and initializer interfaces. Columns marked as `GENERATED BY DEFAULT` are marked as optional.

Things are slightly different for kanel-kysely, as there is only one interface used to generate the different New and Update types. I've chosen to turn `GENERATED ALWAYS` columns to type `never` for New and Update types. The resulting New and Update types look accurate.

I don't use kanel-knex or kanel-zod, so more fixes may be needed there.