### PR TITLE
Add note about branded id types.

### DIFF
--- a/packages/kanel-kysely/README.md
+++ b/packages/kanel-kysely/README.md
@@ -52,3 +52,23 @@ module.exports = {
   preRenderHooks: [makeKyselyHook()],
 };
 ```
+
+## Note About Branded IDs
+Kanel generates some types with extra guards.
+
+```typescript
+/** Identifier type for actor */
+export type ActorId = number & { __flavor?: 'ActorId' };
+```
+
+`{ __flavor?: 'ActorId' }` exists at build time and *not at runtime*. It will prevent you from accidentally passing an incorrect value for the Id.
+
+To pass a string value as primary key or foreign key reference, just add a type assertion for the `<table>Id` generated type.
+
+In cases such as subqueries, the type assertion will happen automatically.
+
+
+
+
+
+


### PR DESCRIPTION
I used the example branded type `ActorId` to explain how this type should be used and why it is written the way it is.