### PR TITLE
kanel-kysely: Differentiate null and undefined for insert types

### DIFF
--- a/packages/kanel-kysely/example/models/public/Actor.ts
+++ b/packages/kanel-kysely/example/models/public/Actor.ts
@@ -7,13 +7,13 @@ export type ActorId = number;
 
 /** Represents the table public.actor */
 export default interface ActorTable {
-  actor_id: ColumnType<ActorId, ActorId | null, ActorId>;
+  actor_id: ColumnType<ActorId, ActorId | undefined, ActorId>;
 
   first_name: ColumnType<string, string, string>;
 
   last_name: ColumnType<string, string, string>;
 
-  last_update: ColumnType<Date, Date | string | null, Date | string>;
+  last_update: ColumnType<Date, Date | string | undefined, Date | string>;
 }
 
 export type Actor = Selectable<ActorTable>;

--- a/packages/kanel-kysely/example/models/public/Address.ts
+++ b/packages/kanel-kysely/example/models/public/Address.ts
@@ -8,7 +8,7 @@ export type AddressId = number;
 
 /** Represents the table public.address */
 export default interface AddressTable {
-  address_id: ColumnType<AddressId, AddressId | null, AddressId>;
+  address_id: ColumnType<AddressId, AddressId | undefined, AddressId>;
 
   address: ColumnType<string, string, string>;
 
@@ -22,7 +22,7 @@ export default interface AddressTable {
 
   phone: ColumnType<string, string, string>;
 
-  last_update: ColumnType<Date, Date | string | null, Date | string>;
+  last_update: ColumnType<Date, Date | string | undefined, Date | string>;
 }
 
 export type Address = Selectable<AddressTable>;

--- a/packages/kanel-kysely/example/models/public/Category.ts
+++ b/packages/kanel-kysely/example/models/public/Category.ts
@@ -7,11 +7,11 @@ export type CategoryId = number;
 
 /** Represents the table public.category */
 export default interface CategoryTable {
-  category_id: ColumnType<CategoryId, CategoryId | null, CategoryId>;
+  category_id: ColumnType<CategoryId, CategoryId | undefined, CategoryId>;
 
   name: ColumnType<string, string, string>;
 
-  last_update: ColumnType<Date, Date | string | null, Date | string>;
+  last_update: ColumnType<Date, Date | string | undefined, Date | string>;
 }
 
 export type Category = Selectable<CategoryTable>;

--- a/packages/kanel-kysely/example/models/public/City.ts
+++ b/packages/kanel-kysely/example/models/public/City.ts
@@ -8,13 +8,13 @@ export type CityId = number;
 
 /** Represents the table public.city */
 export default interface CityTable {
-  city_id: ColumnType<CityId, CityId | null, CityId>;
+  city_id: ColumnType<CityId, CityId | undefined, CityId>;
 
   city: ColumnType<string, string, string>;
 
   country_id: ColumnType<CountryId, CountryId, CountryId>;
 
-  last_update: ColumnType<Date, Date | string | null, Date | string>;
+  last_update: ColumnType<Date, Date | string | undefined, Date | string>;
 }
 
 export type City = Selectable<CityTable>;

--- a/packages/kanel-kysely/example/models/public/Country.ts
+++ b/packages/kanel-kysely/example/models/public/Country.ts
@@ -7,11 +7,11 @@ export type CountryId = number;
 
 /** Represents the table public.country */
 export default interface CountryTable {
-  country_id: ColumnType<CountryId, CountryId | null, CountryId>;
+  country_id: ColumnType<CountryId, CountryId | undefined, CountryId>;
 
   country: ColumnType<string, string, string>;
 
-  last_update: ColumnType<Date, Date | string | null, Date | string>;
+  last_update: ColumnType<Date, Date | string | undefined, Date | string>;
 }
 
 export type Country = Selectable<CountryTable>;

--- a/packages/kanel-kysely/example/models/public/Customer.ts
+++ b/packages/kanel-kysely/example/models/public/Customer.ts
@@ -8,7 +8,7 @@ export type CustomerId = number;
 
 /** Represents the table public.customer */
 export default interface CustomerTable {
-  customer_id: ColumnType<CustomerId, CustomerId | null, CustomerId>;
+  customer_id: ColumnType<CustomerId, CustomerId | undefined, CustomerId>;
 
   store_id: ColumnType<number, number, number>;
 
@@ -20,9 +20,9 @@ export default interface CustomerTable {
 
   address_id: ColumnType<AddressId, AddressId, AddressId>;
 
-  activebool: ColumnType<boolean, boolean | null, boolean>;
+  activebool: ColumnType<boolean, boolean | undefined, boolean>;
 
-  create_date: ColumnType<Date, Date | string | null, Date | string>;
+  create_date: ColumnType<Date, Date | string | undefined, Date | string>;
 
   last_update: ColumnType<Date | null, Date | string | null, Date | string | null>;
 

--- a/packages/kanel-kysely/example/models/public/Film.ts
+++ b/packages/kanel-kysely/example/models/public/Film.ts
@@ -10,7 +10,7 @@ export type FilmId = number;
 
 /** Represents the table public.film */
 export default interface FilmTable {
-  film_id: ColumnType<FilmId, FilmId | null, FilmId>;
+  film_id: ColumnType<FilmId, FilmId | undefined, FilmId>;
 
   title: ColumnType<string, string, string>;
 
@@ -20,17 +20,17 @@ export default interface FilmTable {
 
   language_id: ColumnType<LanguageId, LanguageId, LanguageId>;
 
-  rental_duration: ColumnType<number, number | null, number>;
+  rental_duration: ColumnType<number, number | undefined, number>;
 
-  rental_rate: ColumnType<string, string | null, string>;
+  rental_rate: ColumnType<string, string | undefined, string>;
 
   length: ColumnType<number | null, number | null, number | null>;
 
-  replacement_cost: ColumnType<string, string | null, string>;
+  replacement_cost: ColumnType<string, string | undefined, string>;
 
   rating: ColumnType<MpaaRating | null, MpaaRating | null, MpaaRating | null>;
 
-  last_update: ColumnType<Date, Date | string | null, Date | string>;
+  last_update: ColumnType<Date, Date | string | undefined, Date | string>;
 
   special_features: ColumnType<string[] | null, string[] | null, string[] | null>;
 

--- a/packages/kanel-kysely/example/models/public/FilmActor.ts
+++ b/packages/kanel-kysely/example/models/public/FilmActor.ts
@@ -11,7 +11,7 @@ export default interface FilmActorTable {
 
   film_id: ColumnType<FilmId, FilmId, FilmId>;
 
-  last_update: ColumnType<Date, Date | string | null, Date | string>;
+  last_update: ColumnType<Date, Date | string | undefined, Date | string>;
 }
 
 export type FilmActor = Selectable<FilmActorTable>;

--- a/packages/kanel-kysely/example/models/public/FilmCategory.ts
+++ b/packages/kanel-kysely/example/models/public/FilmCategory.ts
@@ -11,7 +11,7 @@ export default interface FilmCategoryTable {
 
   category_id: ColumnType<CategoryId, CategoryId, CategoryId>;
 
-  last_update: ColumnType<Date, Date | string | null, Date | string>;
+  last_update: ColumnType<Date, Date | string | undefined, Date | string>;
 }
 
 export type FilmCategory = Selectable<FilmCategoryTable>;

--- a/packages/kanel-kysely/example/models/public/Inventory.ts
+++ b/packages/kanel-kysely/example/models/public/Inventory.ts
@@ -8,13 +8,13 @@ export type InventoryId = number;
 
 /** Represents the table public.inventory */
 export default interface InventoryTable {
-  inventory_id: ColumnType<InventoryId, InventoryId | null, InventoryId>;
+  inventory_id: ColumnType<InventoryId, InventoryId | undefined, InventoryId>;
 
   film_id: ColumnType<FilmId, FilmId, FilmId>;
 
   store_id: ColumnType<number, number, number>;
 
-  last_update: ColumnType<Date, Date | string | null, Date | string>;
+  last_update: ColumnType<Date, Date | string | undefined, Date | string>;
 }
 
 export type Inventory = Selectable<InventoryTable>;

--- a/packages/kanel-kysely/example/models/public/Language.ts
+++ b/packages/kanel-kysely/example/models/public/Language.ts
@@ -7,11 +7,11 @@ export type LanguageId = number;
 
 /** Represents the table public.language */
 export default interface LanguageTable {
-  language_id: ColumnType<LanguageId, LanguageId | null, LanguageId>;
+  language_id: ColumnType<LanguageId, LanguageId | undefined, LanguageId>;
 
   name: ColumnType<string, string, string>;
 
-  last_update: ColumnType<Date, Date | string | null, Date | string>;
+  last_update: ColumnType<Date, Date | string | undefined, Date | string>;
 }
 
 export type Language = Selectable<LanguageTable>;

--- a/packages/kanel-kysely/example/models/public/Payment.ts
+++ b/packages/kanel-kysely/example/models/public/Payment.ts
@@ -10,7 +10,7 @@ export type PaymentId = number;
 
 /** Represents the table public.payment */
 export default interface PaymentTable {
-  payment_id: ColumnType<PaymentId, PaymentId | null, PaymentId>;
+  payment_id: ColumnType<PaymentId, PaymentId | undefined, PaymentId>;
 
   customer_id: ColumnType<CustomerId, CustomerId, CustomerId>;
 

--- a/packages/kanel-kysely/example/models/public/Rental.ts
+++ b/packages/kanel-kysely/example/models/public/Rental.ts
@@ -10,7 +10,7 @@ export type RentalId = number;
 
 /** Represents the table public.rental */
 export default interface RentalTable {
-  rental_id: ColumnType<RentalId, RentalId | null, RentalId>;
+  rental_id: ColumnType<RentalId, RentalId | undefined, RentalId>;
 
   rental_date: ColumnType<Date, Date | string, Date | string>;
 
@@ -22,7 +22,7 @@ export default interface RentalTable {
 
   staff_id: ColumnType<StaffId, StaffId, StaffId>;
 
-  last_update: ColumnType<Date, Date | string | null, Date | string>;
+  last_update: ColumnType<Date, Date | string | undefined, Date | string>;
 }
 
 export type Rental = Selectable<RentalTable>;

--- a/packages/kanel-kysely/example/models/public/Staff.ts
+++ b/packages/kanel-kysely/example/models/public/Staff.ts
@@ -9,7 +9,7 @@ export type StaffId = number;
 
 /** Represents the table public.staff */
 export default interface StaffTable {
-  staff_id: ColumnType<StaffId, StaffId | null, StaffId>;
+  staff_id: ColumnType<StaffId, StaffId | undefined, StaffId>;
 
   first_name: ColumnType<string, string, string>;
 
@@ -21,13 +21,13 @@ export default interface StaffTable {
 
   store_id: ColumnType<number, number, number>;
 
-  active: ColumnType<boolean, boolean | null, boolean>;
+  active: ColumnType<boolean, boolean | undefined, boolean>;
 
   username: ColumnType<string, string, string>;
 
   password: ColumnType<string | null, string | null, string | null>;
 
-  last_update: ColumnType<Date, Date | string | null, Date | string>;
+  last_update: ColumnType<Date, Date | string | undefined, Date | string>;
 
   picture: ColumnType<bytea | null, bytea | null, bytea | null>;
 }

--- a/packages/kanel-kysely/example/models/public/Store.ts
+++ b/packages/kanel-kysely/example/models/public/Store.ts
@@ -9,13 +9,13 @@ export type StoreId = number;
 
 /** Represents the table public.store */
 export default interface StoreTable {
-  store_id: ColumnType<StoreId, StoreId | null, StoreId>;
+  store_id: ColumnType<StoreId, StoreId | undefined, StoreId>;
 
   manager_staff_id: ColumnType<StaffId, StaffId, StaffId>;
 
   address_id: ColumnType<AddressId, AddressId, AddressId>;
 
-  last_update: ColumnType<Date, Date | string | null, Date | string>;
+  last_update: ColumnType<Date, Date | string | undefined, Date | string>;
 }
 
 export type Store = Selectable<StoreTable>;

--- a/packages/kanel-kysely/src/processFile.ts
+++ b/packages/kanel-kysely/src/processFile.ts
@@ -104,13 +104,17 @@ const processFile = (
             if (baseType === "Date") {
               baseType += " | string";
             }
-            initializerType =
-              column.isNullable ||
+
+            initializerType = baseType;
+            if (column.isNullable) {
+              initializerType += " | null";
+            } else if (
               column.defaultValue ||
               column.isIdentity ||
               column.generated === "BY DEFAULT"
-                ? `${baseType} | null`
-                : baseType;
+            ) {
+              initializerType += " | undefined";
+            }
           }
 
           let mutatorType = "never";


### PR DESCRIPTION
If a column is not nullable, we should not allow `null` in the insert (results in database error). However we may still allow `undefined` in the insert for generated columns and columns with default value.