### PR TITLE
fix(kanel-zod): remove double semicolon

### DIFF
--- a/packages/kanel-zod/src/processComposite.ts
+++ b/packages/kanel-zod/src/processComposite.ts
@@ -64,7 +64,7 @@ function makeDeclaration(
   if (config.castToSchema) {
     value.push(`}) as unknown as z.Schema<${typescriptTypeName}>`);
   } else {
-    value.push("});");
+    value.push("})");
   }
   properties.forEach((p) => {
     typeImports.push(...p.typeImports);


### PR DESCRIPTION
The semicolon is already added by core kanel renderer: 
https://github.com/kristiandupont/kanel/blob/b03f4bc052d363e84c176772e78f503d13994b55/packages/kanel/src/render.ts#L123-L125