### PR TITLE
added typescript extension as config candidate

### DIFF
--- a/packages/kanel/src/cli/main.ts
+++ b/packages/kanel/src/cli/main.ts
@@ -77,7 +77,7 @@ export async function main(): Promise<void> {
   let configPath: string | undefined;
   const configCandidates = options.config
     ? [options.config]
-    : [".kanelrc.js", ".kanelrc.cjs", ".kanelrc.json"];
+    : [".kanelrc.js", ".kanelrc.cjs", ".kanelrc.json", ".kanelrc.ts"];
   for (const filename of configCandidates) {
     const candidatePath = path.join(process.cwd(), filename);
     if (fs.existsSync(candidatePath)) {


### PR DESCRIPTION
A Typescript-first project will typically .gitignore all JavaScript (.js) extensions from being committed to the repo. Special rules need to be put in place to include a file that is only allowed to have a non-Typescript extension. This is a quality-of-life improvement for Typescript-first projects.