### PR TITLE
removed extra semicolon from generated zod enum

### DIFF
--- a/packages/kanel-zod/src/processEnum.ts
+++ b/packages/kanel-zod/src/processEnum.ts
@@ -20,7 +20,7 @@ const processEnum = (
   const lines: string[] = [
     `z.enum([`,
     ...e.values.map((v) => `  '${v}',`),
-    "]);",
+    "])",
   ];
 
   const typeImport: TypeImport = {


### PR DESCRIPTION
Zod enums were being generated with 2 semicolons at the end of the declaration:
```
export const accountTypes = z.enum([
    '401A',
    '401K',
]);;
```
Removed the extra semicolon.