### PR TITLE
Optinal schema prefix to table name

### DIFF
--- a/packages/kanel-kysely/src/MakeKyselyConfig.ts
+++ b/packages/kanel-kysely/src/MakeKyselyConfig.ts
@@ -3,6 +3,7 @@ import { escapeIdentifier } from "kanel";
 
 interface MakeKyselyConfig {
   databaseFilename: string;
+  includeSchemaNameInTableName: boolean;
   getKyselyItemMetadata?: (
     d: CompositeDetails,
     selectorName: string,
@@ -19,6 +20,7 @@ interface MakeKyselyConfig {
 
 export const defaultConfig: MakeKyselyConfig = {
   databaseFilename: "Database",
+  includeSchemaNameInTableName: false,
   getKyselyItemMetadata: (d, selectorName, canInitialize, canMutate) => ({
     tableInterfaceName: `${escapeIdentifier(selectorName)}Table`,
     selectableName: escapeIdentifier(selectorName),

--- a/packages/kanel-kysely/src/makeKyselyHook.ts
+++ b/packages/kanel-kysely/src/makeKyselyHook.ts
@@ -54,6 +54,7 @@ const makeKyselyHook: (makeKyselyConfig?: MakeKyselyConfig) => PreRenderHook =
             makeKyselyConfig,
           );
         output[path].declarations = modifiedDeclarations;
+        if(makeKyselyConfig.includeSchemaNameInTableName) tableProperty.name = `${schemaName}.${tableProperty.name}`
         tableImports.push(tableImport);
         tableProps.push(tableProperty);
 
@@ -98,7 +99,7 @@ const makeKyselyHook: (makeKyselyConfig?: MakeKyselyConfig) => PreRenderHook =
       name: "Database",
       typeImports: schemaImports,
       typeDefinition: [
-        schemaImports.map((dbImport) => dbImport.name).join(" | "),
+        schemaImports.map((dbImport) => dbImport.name).join(" & "),
       ],
       exportAs: "default",
     };


### PR DESCRIPTION
Addresses and closes #521  

1. Changed type union `|` to intersection `&` because with union kysely Database type breaks.
So if for example Database type defined as `type Database = PublicSchema | PrivateSchema;` kysely instance will infer `never` as a table type `QueryCreator<Database>.selectFrom<never>(from: never[]): SelectQueryBuilder<Database, never, {}> (+4 overloads)`, it breaks only autocomplition and doesnt influence actual functionality.
2. Added optional schema prefix to a table name in schema interface to prevent possible collisions. Resulting in, assuming schema public has table example to be transfomed like this `example` => `"public.example"`. Affects **only** schema interface.
3. Added `includeSchemaNameInTableName` property that defaults to false and indicates if table names should be prefixed by schema name.

I'm not very experienced in contributing to open source so would appreciate any feedback :)

