### PR TITLE
Add `kyselyCamelCaseHook`

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -8168,7 +8168,7 @@
       }
     },
     "packages/kanel": {
-      "version": "3.8.8",
+      "version": "3.8.9",
       "license": "MIT",
       "dependencies": {
         "@kristiandupont/recase": "^1.2.1",
@@ -8204,14 +8204,15 @@
       }
     },
     "packages/kanel-kysely": {
-      "version": "0.3.3",
+      "version": "0.4.0",
       "license": "MIT",
       "dependencies": {
         "@kristiandupont/recase": "^1.2.1"
       },
       "devDependencies": {
         "extract-pg-schema": "^5.0.0",
-        "kanel": "*"
+        "kanel": "*",
+        "vitest": "^1.6.0"
       }
     },
     "packages/kanel-seeder": {

--- a/packages/kanel-kysely/README.md
+++ b/packages/kanel-kysely/README.md
@@ -67,3 +67,17 @@ export type ActorId = number & { __flavor?: "ActorId" };
 To pass a string value as primary key or foreign key reference, just add a type assertion for the `<table>Id` generated type.
 
 In cases such as subqueries, the type assertion will happen automatically.
+
+## Usage with `CamelCasePlugin`
+
+If you use Kysely with `CamelCasePlugin` then append `kyselyCamelCaseHook` to `preRenderHooks`:
+
+```ts
+const { makeKyselyHook, kyselyCamelCaseHook } = require("kanel-kysely");
+
+module.exports = {
+  // ... your config here.
+
+  preRenderHooks: [makeKyselyHook(), kyselyCamelCaseHook],
+};
+```

--- a/packages/kanel-kysely/package.json
+++ b/packages/kanel-kysely/package.json
@@ -25,12 +25,13 @@
   "license": "MIT",
   "scripts": {
     "build": "rm -rf ./build && tsc",
-    "test": "echo TODO...",
+    "test": "vitest run",
     "run-example": "kanel -c ./example/.kanelrc"
   },
   "devDependencies": {
     "extract-pg-schema": "^5.0.0",
-    "kanel": "*"
+    "kanel": "*",
+    "vitest": "^1.6.0"
   },
   "dependencies": {
     "@kristiandupont/recase": "^1.2.1"

--- a/packages/kanel-kysely/src/index.ts
+++ b/packages/kanel-kysely/src/index.ts
@@ -1,1 +1,2 @@
+export { kyselyCamelCaseHook } from "./kyselyCamelCaseHook";
 export { default as makeKyselyHook } from "./makeKyselyHook";

--- a/packages/kanel-kysely/src/kyselyCamelCaseHook.test.ts
+++ b/packages/kanel-kysely/src/kyselyCamelCaseHook.test.ts
@@ -1,0 +1,94 @@
+import type { InstantiatedConfig } from "kanel";
+import { assert, expect, it } from "vitest";
+
+import { kyselyCamelCaseHook } from "./kyselyCamelCaseHook.js";
+
+it("Should transform all properties to camelCase", async () => {
+  const output = await kyselyCamelCaseHook(
+    {
+      foo: {
+        declarations: [
+          {
+            declarationType: "interface",
+            name: "Member",
+            exportAs: "default",
+            properties: [
+              {
+                name: "snake_case",
+                typeName: "string",
+                dimensions: 0,
+                isOptional: false,
+                isNullable: false,
+              },
+            ],
+          },
+          {
+            declarationType: "interface",
+            name: "Member",
+            exportAs: "default",
+            properties: [
+              {
+                name: "SCREAMING_SNAKE_CASE",
+                typeName: "string",
+                dimensions: 0,
+                isOptional: false,
+                isNullable: false,
+              },
+            ],
+          },
+        ],
+      },
+      bar: {
+        declarations: [
+          {
+            declarationType: "interface",
+            name: "Member",
+            exportAs: "default",
+            properties: [
+              {
+                name: "kebab-case",
+                typeName: "string",
+                dimensions: 0,
+                isOptional: false,
+                isNullable: false,
+              },
+              {
+                name: "PascalCase",
+                typeName: "string",
+                dimensions: 0,
+                isOptional: false,
+                isNullable: false,
+              },
+              {
+                name: "sTuDlYcApS",
+                typeName: "string",
+                dimensions: 0,
+                isOptional: false,
+                isNullable: false,
+              },
+            ],
+          },
+        ],
+      },
+    },
+    undefined as InstantiatedConfig,
+  );
+
+  assert("properties" in output["foo"].declarations[0]);
+  assert("properties" in output["foo"].declarations[1]);
+  assert("properties" in output["bar"].declarations[0]);
+
+  expect(
+    [
+      ...output["foo"].declarations[0].properties,
+      ...output["foo"].declarations[1].properties,
+      ...output["bar"].declarations[0].properties,
+    ].map((x) => x.name),
+  ).toEqual([
+    "snakeCase",
+    "sCREAMINGSNAKECASE",
+    "kebabCase",
+    "pascalCase",
+    "sTuDlYcApS",
+  ]);
+});

--- a/packages/kanel-kysely/src/kyselyCamelCaseHook.ts
+++ b/packages/kanel-kysely/src/kyselyCamelCaseHook.ts
@@ -1,0 +1,25 @@
+import { recase } from "@kristiandupont/recase";
+import type { PreRenderHook } from "kanel";
+
+const toCamelCase = recase(null, "camel");
+
+export const kyselyCamelCaseHook: PreRenderHook = (output) =>
+  Object.fromEntries(
+    Object.entries(output).map(([path, fileContents]) => [
+      path,
+      {
+        ...fileContents,
+        declarations: fileContents.declarations.map((declaration) =>
+          declaration.declarationType === "interface"
+            ? {
+                ...declaration,
+                properties: declaration.properties.map((property) => ({
+                  ...property,
+                  name: toCamelCase(property.name),
+                })),
+              }
+            : declaration,
+        ),
+      },
+    ]),
+  );

--- a/packages/kanel-kysely/vitest.config.ts
+++ b/packages/kanel-kysely/vitest.config.ts
@@ -1,0 +1,7 @@
+import { defineConfig } from "vitest/config";
+
+export default defineConfig({
+  test: {
+    include: ["src/**/*.{test,spec}.{js,mjs,cjs,ts,mts,cts,jsx,tsx}"],
+  },
+});


### PR DESCRIPTION
Fixes https://github.com/kristiandupont/kanel/issues/547. I just started using Kysely (and Kanel) myself, so a second set of eyes would be welcome. I didn't build the docs because even if I pin `vitepress` to `1.0.0-rc.31` it still creates new assets, so I leave it to you 😉 