### PR TITLE
Fix description text in package.json

### DIFF
--- a/packages/kanel-kysely/package.json
+++ b/packages/kanel-kysely/package.json
@@ -11,7 +11,7 @@
     "type": "git",
     "url": "git+https://github.com/kristiandupont/kanel.git"
   },
-  "description": "Zod extension for Kanel",
+  "description": "Kysely extension for Kanel",
   "homepage": "https://kristiandupont.github.io/kanel",
   "author": {
     "name": "Kristian Dupont",


### PR DESCRIPTION
Replaces reference to `Zod` with `Kysely` in `kanel-kysely`