### PR TITLE
Add _text to defaultTypeMap

### DIFF
--- a/packages/kanel/src/defaultTypeMap.ts
+++ b/packages/kanel/src/defaultTypeMap.ts
@@ -33,6 +33,7 @@ const defaultTypeMap: TypeMap = {
   "pg_catalog.tsrange": "string",
   "pg_catalog.tstzrange": "string",
   "pg_catalog.daterange": "string",
+  "pg_catalog._text": "string",
 };
 
 export default defaultTypeMap;


### PR DESCRIPTION
When copying tables with `TEXT[]` column type by doing `CREATE TABLE my_table (LIKE my_other_table INCLUDING ALL);` the column data type gets set to `_text`. This fixes those as being strings.