### PR TITLE
fixed crashing on empty schema

### DIFF
--- a/packages/kanel-kysely/src/makeKyselyHook.ts
+++ b/packages/kanel-kysely/src/makeKyselyHook.ts
@@ -33,6 +33,9 @@ const makeKyselyHook: (makeKyselyConfig?: MakeKyselyConfig) => PreRenderHook =
         ...schema.materializedViews,
         ...schema.compositeTypes,
       ];
+      if (composites.length === 0) {
+        continue;
+      }
       // Get the schema folder from the first known composite.
       let schemaFolder: string | undefined;
 


### PR DESCRIPTION
Addresses and closes #648

1. Added empty `composites` guard at [packages/kanel-kysely/src/makeKyselyHook.ts](https://github.com/kristiandupont/kanel/blob/bc240d0/packages/kanel-kysely/src/makeKyselyHook.ts) to prevent crashing when processed schema doesnt have `tables`, `views`, `materializedViews ` or `compositeTypes`. Empty `composites` causes `schemaFolder` to be undefined when generating `schemaPath` and causing path.join to error out.
This skips "empy" schema processing completely which might be undesired behaviour. Alternaive way to fix it is to generate `schemaFolder` outside of `composites` forEach loop but i suspect it requires changes to `extractSchemas` function from  `extract-pg-schema` package or `InstantiatedConfig`.

Pls lmk if its good enougth or there is a better way and i should refactor. Ty, great lib appreciate your work❤️
