### PR TITLE
fix(kanel-zod): import and assign composite types

### DIFF
--- a/packages/kanel-zod/src/generateProperties.ts
+++ b/packages/kanel-zod/src/generateProperties.ts
@@ -19,6 +19,7 @@ const generateProperties = <D extends CompositeDetails>(
   details: D,
   generateFor: "selector" | "initializer" | "mutator",
   nonCompositeTypeImports: Record<string, TypeImport>,
+  compositeTypeImports: Record<string, TypeImport>,
   identifierTypeImports: Record<string, TypeImport>,
   config: GenerateZodSchemasConfig,
   instantiatedConfig: InstantiatedConfig,
@@ -66,6 +67,10 @@ const generateProperties = <D extends CompositeDetails>(
         }
       } else if (p.type.fullName in nonCompositeTypeImports) {
         const x = nonCompositeTypeImports[p.type.fullName];
+        typeImports.push(x);
+        zodType = x.name;
+      } else if (p.type.fullName in compositeTypeImports) {
+        const x = compositeTypeImports[p.type.fullName];
         typeImports.push(x);
         zodType = x.name;
       } else {

--- a/packages/kanel-zod/src/generateZodSchemas.ts
+++ b/packages/kanel-zod/src/generateZodSchemas.ts
@@ -37,6 +37,7 @@ export const makeGenerateZodSchemas =
 
     const nonCompositeTypeImports: Record<string, TypeImport> = {};
     const identifierTypeImports: Record<string, TypeImport> = {};
+    const compositeTypeImports: Record<string, TypeImport> = {};
 
     // First, process the non-composite types. These may be imported by
     // the composed ones so we will generate them first and store them
@@ -157,6 +158,25 @@ export const makeGenerateZodSchemas =
         }
       });
       // #endregion identifiers
+
+      // #region composites
+      schema.compositeTypes.forEach((compositeDetails) => {
+        const { name, path } = config.getZodSchemaMetadata(
+          compositeDetails,
+          undefined,
+          instantiatedConfig,
+        );
+        compositeTypeImports[
+          `${compositeDetails.schemaName}.${compositeDetails.name}`
+        ] = {
+          name,
+          path,
+          isDefault: false,
+          isAbsolute: false,
+          importAsType: false,
+        };
+      });
+      // #endregion composites
     }
 
     // #region composites
@@ -179,6 +199,7 @@ export const makeGenerateZodSchemas =
           config,
           instantiatedConfig,
           nonCompositeTypeImports,
+          compositeTypeImports,
           identifierTypeImports,
         );
         for (const declaration of declarations) {

--- a/packages/kanel-zod/src/processComposite.ts
+++ b/packages/kanel-zod/src/processComposite.ts
@@ -15,6 +15,7 @@ function makeDeclaration(
   c: CompositeDetails,
   generateFor: "selector" | "initializer" | "mutator",
   nonCompositeTypeImports: Record<string, TypeImport>,
+  compositeTypeImports: Record<string, TypeImport>,
   identifierTypeImports: Record<string, TypeImport>,
   config: GenerateZodSchemasConfig,
 ) {
@@ -34,6 +35,7 @@ function makeDeclaration(
     c,
     generateFor,
     nonCompositeTypeImports,
+    compositeTypeImports,
     identifierTypeImports,
     config,
     instantiatedConfig,
@@ -87,6 +89,7 @@ const processComposite = (
   config: GenerateZodSchemasConfig,
   instantiatedConfig: InstantiatedConfig,
   nonCompositeTypeImports: Record<string, TypeImport>,
+  compositeTypeImports: Record<string, TypeImport>,
   identifierTypeImports: Record<string, TypeImport>,
 ): ConstantDeclaration[] => {
   const declarations: ConstantDeclaration[] = [];
@@ -96,6 +99,7 @@ const processComposite = (
     c,
     "selector",
     nonCompositeTypeImports,
+    compositeTypeImports,
     identifierTypeImports,
     config,
   );
@@ -107,6 +111,7 @@ const processComposite = (
       c,
       "initializer",
       nonCompositeTypeImports,
+      compositeTypeImports,
       identifierTypeImports,
       config,
     );
@@ -117,6 +122,7 @@ const processComposite = (
       c,
       "mutator",
       nonCompositeTypeImports,
+      compositeTypeImports,
       identifierTypeImports,
       config,
     );


### PR DESCRIPTION
I noticed that kanel-zod generates zod types for composite types, but doesn't name them in the table, so it resulted in

```TS
custom: undefined.optional().nullable(),
        ~~~~~~~~~
```

I've made some changes so composite types will be imported and named correctly. Seems to work fine on my local test, let me know if I've missed something.