### PR TITLE
fix(kanel-zod): branded ID type, qualifiers for composite types

### DIFF
--- a/packages/kanel-zod/src/generateProperties.ts
+++ b/packages/kanel-zod/src/generateProperties.ts
@@ -51,7 +51,7 @@ const generateProperties = <D extends CompositeDetails>(
       if (typeof t !== "string" && t.name in identifierTypeImports) {
         const x = identifierTypeImports[t.name];
         typeImports.push(x);
-        zodType = `${x.name}.transform(value => value as ${t.name})`;
+        zodType = x.name;
       } else if (p.type.fullName in config.zodTypeMap) {
         const x = config.zodTypeMap[p.type.fullName];
         if (typeof x === "string") {

--- a/packages/kanel-zod/src/generateProperties.ts
+++ b/packages/kanel-zod/src/generateProperties.ts
@@ -51,7 +51,7 @@ const generateProperties = <D extends CompositeDetails>(
       if (typeof t !== "string" && t.name in identifierTypeImports) {
         const x = identifierTypeImports[t.name];
         typeImports.push(x);
-        zodType = x.name;
+        zodType = `${x.name}.transform(value => value as ${t.name})`;
       } else if (p.type.fullName in config.zodTypeMap) {
         const x = config.zodTypeMap[p.type.fullName];
         if (typeof x === "string") {
@@ -73,6 +73,8 @@ const generateProperties = <D extends CompositeDetails>(
         const x = compositeTypeImports[p.type.fullName];
         typeImports.push(x);
         zodType = x.name;
+        if (p.isArray) zodType = `${zodType}.array()`;
+        if (p.isNullable) zodType = `${zodType}.nullable()`;
       } else {
         console.error(
           `kanel-zod: Unknown type for ${name}.${p.name}: ${p.type.fullName}`,

--- a/packages/kanel-zod/src/getIdentifierDeclaration.ts
+++ b/packages/kanel-zod/src/getIdentifierDeclaration.ts
@@ -72,7 +72,7 @@ const getIdentifierDeclaration = (
         type: undefined,
         value: config.castToSchema
           ? `${zodType} as unknown as z.Schema<${typescriptDeclaration.name}>`
-          : zodType,
+          : `${zodType}.transform(value => value as ${typescriptDeclaration.name})`,
         exportAs: "named",
       };
 


### PR DESCRIPTION
This makes two changes:

### 1. Branded IDs just get cast implicitly by the Zod schema

```diff
- export const eventsId = z.number();
+ export const eventsId = z.number().transform(value => value as EventsId);
```

This might make `castToSchema` redundant (? I'm not sure what other purpose this option serves. I'd be happy to remove it entirely if nothing else)

### 2. Adds qualifiers to composite type properties

This fixes an oversight in #653.