### PR TITLE
Kysely: allow composite type props to be Insertable and Updateable

### DIFF
--- a/packages/kanel-kysely/src/processFile.ts
+++ b/packages/kanel-kysely/src/processFile.ts
@@ -48,7 +48,10 @@ const processFile = (
   let canInitialize = true;
   let canMutate = true;
 
-  if (compositeDetails.kind !== "table") {
+  if (
+    compositeDetails.kind !== "table" &&
+    compositeDetails.kind !== "compositeType"
+  ) {
     canInitialize = false;
     canMutate = false;
   }
@@ -157,40 +160,42 @@ const processFile = (
     exportAs: "named",
   });
 
-  if (insertableName) {
-    result.push({
-      declarationType: "typeDeclaration",
-      name: insertableName,
-      typeImports: [
-        {
-          name: "Insertable",
-          isDefault: false,
-          path: "kysely",
-          isAbsolute: true,
-          importAsType: true,
-        },
-      ],
-      typeDefinition: [`Insertable<${tableInterfaceName}>`],
-      exportAs: "named",
-    });
-  }
+  if (compositeDetails.kind !== "compositeType") {
+    if (insertableName) {
+      result.push({
+        declarationType: "typeDeclaration",
+        name: insertableName,
+        typeImports: [
+          {
+            name: "Insertable",
+            isDefault: false,
+            path: "kysely",
+            isAbsolute: true,
+            importAsType: true,
+          },
+        ],
+        typeDefinition: [`Insertable<${tableInterfaceName}>`],
+        exportAs: "named",
+      });
+    }
 
-  if (updatableName) {
-    result.push({
-      declarationType: "typeDeclaration",
-      name: updatableName,
-      typeImports: [
-        {
-          name: "Updateable",
-          isDefault: false,
-          path: "kysely",
-          isAbsolute: true,
-          importAsType: true,
-        },
-      ],
-      typeDefinition: [`Updateable<${tableInterfaceName}>`],
-      exportAs: "named",
-    });
+    if (updatableName) {
+      result.push({
+        declarationType: "typeDeclaration",
+        name: updatableName,
+        typeImports: [
+          {
+            name: "Updateable",
+            isDefault: false,
+            path: "kysely",
+            isAbsolute: true,
+            importAsType: true,
+          },
+        ],
+        typeDefinition: [`Updateable<${tableInterfaceName}>`],
+        exportAs: "named",
+      });
+    }
   }
 
   const tableImport: TypeImport = {


### PR DESCRIPTION
This PR makes the following change to composite type tables:

```diff
- name: ColumnType<string | null, never, never>;
+ name: ColumnType<string | null, string | null, string | null>;
```

Previously, composite types could not be inserted or updated because all their properties would just become never. They should just have the same type as base type since no further constraints can be imposed on them without triggers.

The code is a bit messy, this change seemed the least bytes modified solution to get here.