### PR TITLE
add constArray option for enums

### DIFF
--- a/packages/kanel/src/declaration-types.ts
+++ b/packages/kanel/src/declaration-types.ts
@@ -36,6 +36,13 @@ export type EnumDeclaration = DeclarationBase & {
   exportAs: "named" | "default";
 };
 
+export type ConstArrayDeclaration = DeclarationBase & {
+  declarationType: "constArray";
+  name: string;
+  values: string[];
+  exportAs: "named" | "default";
+};
+
 export type ConstantDeclaration = DeclarationBase & {
   declarationType: "constant";
   name: string;
@@ -51,6 +58,7 @@ export type GenericDeclaration = DeclarationBase & {
 };
 
 export type Declaration =
+  | ConstArrayDeclaration
   | TypeDeclaration
   | InterfaceDeclaration
   | EnumDeclaration

--- a/packages/kanel/src/generators/makeEnumsGenerator.ts
+++ b/packages/kanel/src/generators/makeEnumsGenerator.ts
@@ -3,6 +3,7 @@ import { tryParse } from "tagged-comment-parser";
 
 import type { InstantiatedConfig } from "../config-types";
 import type {
+  ConstArrayDeclaration,
   Declaration,
   EnumDeclaration,
   TypeDeclaration,
@@ -10,7 +11,7 @@ import type {
 import type { Path } from "../Output";
 import type Output from "../Output";
 
-type EnumStyle = "enum" | "type";
+type EnumStyle = "enum" | "type" | "constArray";
 
 const makeMapper =
   (style: EnumStyle, config: InstantiatedConfig) =>
@@ -40,6 +41,15 @@ const makeMapper =
           "", // Start definition on new line
           ...enumDetails.values.map((value) => `| '${value}'`),
         ],
+      };
+      return { path, declaration };
+    } else if (style === "constArray") {
+      const declaration: ConstArrayDeclaration = {
+        declarationType: "constArray",
+        comment,
+        name,
+        exportAs: "default",
+        values: enumDetails.values,
       };
       return { path, declaration };
     } else {

--- a/packages/kanel/src/hooks/generateIndexFile.ts
+++ b/packages/kanel/src/hooks/generateIndexFile.ts
@@ -3,6 +3,7 @@ import { join, relative, sep } from "path";
 import type { PreRenderHook } from "../config-types";
 import type {
   ConstantDeclaration,
+  ConstArrayDeclaration,
   EnumDeclaration,
   InterfaceDeclaration,
   TypeDeclaration,
@@ -15,6 +16,7 @@ type GenerateIndexFileConfig = {
       | TypeDeclaration
       | InterfaceDeclaration
       | EnumDeclaration
+      | ConstArrayDeclaration
       | ConstantDeclaration,
   ) => boolean;
 };

--- a/packages/kanel/src/render.test.ts
+++ b/packages/kanel/src/render.test.ts
@@ -128,6 +128,42 @@ describe("processGenerationSetup", () => {
     ]);
   });
 
+  it("should process an enum as a const array", () => {
+    const declarations: Declaration[] = [
+      {
+        declarationType: "constArray" as const,
+        name: "MpaaRating",
+        exportAs: "named",
+        values: ["G", "PG", "PG-13", "R", "NC-17"],
+      },
+    ];
+    const lines = render(declarations, "./", instantiatedConfig);
+    expect(lines).toEqual([
+      `export const MpaaRating = [`,
+      `'G', 'PG', 'PG-13', 'R', 'NC-17'`,
+      `] as const;`,
+    ]);
+  });
+
+  it("should support a default exported enum", () => {
+    const declarations: Declaration[] = [
+      {
+        declarationType: "constArray" as const,
+        name: "Fruit",
+        exportAs: "default",
+        values: ["apples", "oranges", "bananas"],
+      },
+    ];
+    const lines = render(declarations, "./", instantiatedConfig);
+    expect(lines).toEqual([
+      "const Fruit = [",
+      "'apples', 'oranges', 'bananas'",
+      "] as const;",
+      "",
+      "export default Fruit;",
+    ]);
+  });
+
   it("should process a constant", () => {
     const declarations: Declaration[] = [
       {

--- a/packages/kanel/src/render.ts
+++ b/packages/kanel/src/render.ts
@@ -117,6 +117,21 @@ const processDeclaration = (
       }
       break;
     }
+    case "constArray": {
+      const { exportAs, name, values, comment } = declaration;
+      declarationLines.push(
+        ...(processComments(comment, 0) || []),
+        exportAs === "named"
+          ? `export const ${escapeIdentifier(name)} = [`
+          : `const ${escapeIdentifier(name)} = [`,
+        values.map((v) => `'${v}'`).join(", "),
+        "] as const;",
+      );
+      if (exportAs === "default") {
+        declarationLines.push("", `export default ${escapeIdentifier(name)};`);
+      }
+      break;
+    }
     case "constant": {
       const { exportAs, name, type, value, comment } = declaration;
       const values = Array.isArray(value) ? value : [value];


### PR DESCRIPTION
This adds a `constArray` option for enums, as discussed in #567.  I haven't actually tested it on my database, but the tests pass.  I will try it out for real, and let you know how it goes.  It should probably export a type as well, so I'll add that.