### PR TITLE
Replace "prop-drilling" with context

### DIFF
--- a/.github/workflows/pull-requests.yml
+++ b/.github/workflows/pull-requests.yml
@@ -7,7 +7,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        node-version: [18.x]
+        node-version: [22.x]
 
     steps:
       - uses: actions/checkout@08c6903cd8c0fde910a37f88322edcfb5dd907a8 # v5

--- a/packages/kanel-zod/src/generateProperties.ts
+++ b/packages/kanel-zod/src/generateProperties.ts
@@ -43,7 +43,7 @@ const generateProperties = <D extends CompositeDetails>(
       const canBeOptional: boolean =
         p.isNullable || p.defaultValue || p.isIdentity;
 
-      const t = typeOverride ?? resolveType(p, details, instantiatedConfig);
+      const t = typeOverride ?? resolveType(p, details);
 
       let zodType: string;
       const typeImports: TypeImport[] = [];

--- a/packages/kanel/src/ImportGenerator.test.ts
+++ b/packages/kanel/src/ImportGenerator.test.ts
@@ -1,26 +1,10 @@
-import { describe, expect, it, vi } from "vitest";
+import { describe, expect, it } from "vitest";
 
-import type { InstantiatedConfig } from "./config-types";
 import ImportGenerator from "./ImportGenerator";
-
-// Mocked InstantiatedConfig
-const instantiatedConfig: InstantiatedConfig = {
-  getMetadata: vi.fn(),
-  getPropertyMetadata: vi.fn(),
-  generateIdentifierType: vi.fn(),
-  propertySortFunction: vi.fn(),
-  enumStyle: "enum",
-  typeMap: {},
-  schemas: {},
-  connection: {},
-  outputPath: ".",
-  preDeleteOutputFolder: false,
-  resolveViews: true,
-};
 
 describe("ImportGenerator", () => {
   it("should generate an import statement", () => {
-    const ig = new ImportGenerator("/src/some-module", instantiatedConfig);
+    const ig = new ImportGenerator("/src/some-module", undefined);
 
     ig.addImport({
       name: "func",
@@ -36,10 +20,7 @@ describe("ImportGenerator", () => {
   });
 
   it("should support various cases", () => {
-    const ig = new ImportGenerator(
-      "/package/src/some-module",
-      instantiatedConfig,
-    );
+    const ig = new ImportGenerator("/package/src/some-module", undefined);
 
     ig.addImport({
       name: "defaultFunc",
@@ -129,7 +110,7 @@ describe("ImportGenerator", () => {
   });
 
   it("should ignore duplicates", () => {
-    const ig = new ImportGenerator("./some-module", instantiatedConfig);
+    const ig = new ImportGenerator("./some-module", undefined);
 
     ig.addImport({
       name: "def",
@@ -180,7 +161,7 @@ describe("ImportGenerator", () => {
   });
 
   it("should complain about multiple (different) default imports", () => {
-    const ig = new ImportGenerator("./some-module", instantiatedConfig);
+    const ig = new ImportGenerator("./some-module", undefined);
 
     ig.addImport({
       name: "def",
@@ -204,7 +185,7 @@ describe("ImportGenerator", () => {
   });
 
   it("should support absolute imports", () => {
-    const ig = new ImportGenerator("./some-module", instantiatedConfig);
+    const ig = new ImportGenerator("./some-module", undefined);
 
     ig.addImport({
       name: "path",
@@ -239,7 +220,7 @@ describe("ImportGenerator", () => {
   });
 
   it("should not import items from the same file", () => {
-    const ig = new ImportGenerator("./src/some-module", instantiatedConfig);
+    const ig = new ImportGenerator("./src/some-module", undefined);
 
     ig.addImport({
       name: "path",
@@ -271,7 +252,7 @@ describe("ImportGenerator", () => {
   });
 
   it("should support type-only imports", () => {
-    const ig = new ImportGenerator("./some-module", instantiatedConfig);
+    const ig = new ImportGenerator("./some-module", undefined);
 
     ig.addImport({
       name: "Member",
@@ -306,7 +287,7 @@ describe("ImportGenerator", () => {
   });
 
   it("should support combinations of type-only and non-type-only imports", () => {
-    const ig = new ImportGenerator("./some-module", instantiatedConfig);
+    const ig = new ImportGenerator("./some-module", undefined);
 
     ig.addImport({
       name: "Member",
@@ -358,7 +339,7 @@ describe("ImportGenerator", () => {
 
   // This is necessary because of https://github.com/tc39/proposal-type-annotations/issues/16
   it("should combine default and named type-only imports correctly", () => {
-    const ig = new ImportGenerator("./some-module", instantiatedConfig);
+    const ig = new ImportGenerator("./some-module", undefined);
 
     ig.addImport({
       name: "Account",
@@ -392,7 +373,7 @@ describe("ImportGenerator", () => {
   });
 
   it("should support renaming imports with asName", () => {
-    const ig = new ImportGenerator("./some-module", instantiatedConfig);
+    const ig = new ImportGenerator("./some-module", undefined);
 
     // Test default import renaming
     ig.addImport({
@@ -431,7 +412,7 @@ describe("ImportGenerator", () => {
   });
 
   it("should handle mixed renamed and non-renamed imports", () => {
-    const ig = new ImportGenerator("./some-module", instantiatedConfig);
+    const ig = new ImportGenerator("./some-module", undefined);
 
     // Mix of renamed and non-renamed imports
     ig.addImport({

--- a/packages/kanel/src/ImportGenerator.ts
+++ b/packages/kanel/src/ImportGenerator.ts
@@ -1,6 +1,5 @@
 import path from "path";
 
-import type { InstantiatedConfig } from "./config-types";
 import escapeString from "./escapeString";
 import type TypeImport from "./TypeImport";
 
@@ -14,15 +13,15 @@ type ImportSet = {
 class ImportGenerator {
   srcFolder: string;
   srcModuleName: string;
-  config: InstantiatedConfig | undefined;
+  importsExtension: string | undefined;
 
   /**
    * @param srcPath The path (including filename) of the module we're generating imports for.
    */
-  constructor(srcPath: string, config: InstantiatedConfig) {
+  constructor(srcPath: string, importsExtension: string | undefined) {
     this.srcFolder = path.dirname(srcPath);
     this.srcModuleName = path.basename(srcPath);
-    this.config = config ?? undefined;
+    this.importsExtension = importsExtension;
   }
 
   importMap: { [index: string]: ImportSet } = {};
@@ -125,7 +124,7 @@ class ImportGenerator {
       }
 
       const extension =
-        (relativePath.includes("./") ? this.config.importsExtension : "") ?? "";
+        (relativePath.includes("./") ? this.importsExtension : "") ?? "";
       const line = `import ${onlyTypeImports ? "type " : ""}${importParts.join(", ")} from '${escapeString(
         relativePath,
       )}${extension}';`;

--- a/packages/kanel/src/context.ts
+++ b/packages/kanel/src/context.ts
@@ -1,0 +1,29 @@
+import { AsyncLocalStorage } from "node:async_hooks";
+import type { InstantiatedConfig } from "./config-types";
+
+export type KanelContext = {
+  instantiatedConfig: InstantiatedConfig;
+};
+
+const asyncLocalStorage = new AsyncLocalStorage<KanelContext>();
+
+export const useKanelContext = (): KanelContext => {
+  const context = asyncLocalStorage.getStore();
+  if (!context) throw new Error("Kanel context not available");
+  return context;
+};
+
+export const runWithContext = async <T>(
+  context: KanelContext,
+  fn: () => Promise<T>,
+): Promise<T> => asyncLocalStorage.run(context, fn);
+
+// Test utility functions
+export const runWithContextSync = <T>(context: KanelContext, fn: () => T): T =>
+  asyncLocalStorage.run(context, fn);
+
+export const createTestContext = (
+  instantiatedConfig: InstantiatedConfig,
+): KanelContext => ({
+  instantiatedConfig,
+});

--- a/packages/kanel/src/default-metadata-generators.test.ts
+++ b/packages/kanel/src/default-metadata-generators.test.ts
@@ -1,16 +1,41 @@
-import { describe, expect, it } from "vitest";
+import { beforeEach, describe, expect, it, vi } from "vitest";
 
 import { defaultGenerateIdentifierType } from "./default-metadata-generators";
 import type { GenerateIdentifierType } from "./metadata-types";
+import type { InstantiatedConfig } from "./config-types";
+import { createTestContext, runWithContextSync } from "./context";
+
+// Mocked InstantiatedConfig
+const instantiatedConfig: InstantiatedConfig = {
+  getMetadata: vi.fn(),
+  getPropertyMetadata: vi.fn(),
+  generateIdentifierType: vi.fn(),
+  propertySortFunction: vi.fn(),
+  enumStyle: "enum",
+  typeMap: {},
+  schemas: {},
+  connection: {},
+  outputPath: ".",
+  preDeleteOutputFolder: false,
+  resolveViews: true,
+};
 
 describe("defaultGenerateIdentifierType", () => {
+  let testContext: ReturnType<typeof createTestContext>;
+
+  beforeEach(() => {
+    testContext = createTestContext(instantiatedConfig);
+  });
+
   it("generates correct identifier type", () => {
-    const result = defaultGenerateIdentifierType(
-      ...([
-        { name: "thing_id", type: { kind: "base", fullName: "text" } },
-        { name: "my_things", schemaName: "public" },
-        { typeMap: {} },
-      ] as Parameters<GenerateIdentifierType>),
+    const result = runWithContextSync(testContext, () =>
+      defaultGenerateIdentifierType(
+        ...([
+          { name: "thing_id", type: { kind: "base", fullName: "text" } },
+          { name: "my_things", schemaName: "public" },
+          { typeMap: {} },
+        ] as Parameters<GenerateIdentifierType>),
+      ),
     );
 
     expect(result).toMatchObject({
@@ -22,12 +47,14 @@ describe("defaultGenerateIdentifierType", () => {
   });
 
   it("generates correct identifier type with special characters", () => {
-    const result = defaultGenerateIdentifierType(
-      ...([
-        { name: "special_col!'.", type: { kind: "base", fullName: "text" } },
-        { name: "special_table!'.", schemaName: "special_schema!'." },
-        { typeMap: {} },
-      ] as Parameters<GenerateIdentifierType>),
+    const result = runWithContextSync(testContext, () =>
+      defaultGenerateIdentifierType(
+        ...([
+          { name: "special_col!'.", type: { kind: "base", fullName: "text" } },
+          { name: "special_table!'.", schemaName: "special_schema!'." },
+          { typeMap: {} },
+        ] as Parameters<GenerateIdentifierType>),
+      ),
     );
 
     expect(result).toMatchObject({

--- a/packages/kanel/src/default-metadata-generators.ts
+++ b/packages/kanel/src/default-metadata-generators.ts
@@ -67,16 +67,12 @@ export const defaultGetPropertyMetadata: GetPropertyMetadata = (
 export const defaultGenerateIdentifierType: GenerateIdentifierType = (
   column,
   details,
-  config,
+  _config,
 ) => {
   const name = escapeIdentifier(
     toPascalCase(details.name) + toPascalCase(column.name),
   );
-  const innerType = resolveType(column, details, {
-    ...config,
-    // Explicitly disable identifier resolution so we get the actual inner type here
-    generateIdentifierType: undefined,
-  });
+  const innerType = resolveType(column, details, true);
   const imports = [];
 
   let type = innerType;

--- a/packages/kanel/src/generators/enumsGenerator.ts
+++ b/packages/kanel/src/generators/enumsGenerator.ts
@@ -1,7 +1,7 @@
 import type { EnumDetails, Schema } from "extract-pg-schema";
 import { tryParse } from "tagged-comment-parser";
 
-import type { InstantiatedConfig } from "../config-types";
+import { useKanelContext } from "../context";
 import type {
   Declaration,
   EnumDeclaration,
@@ -13,10 +13,12 @@ import type Output from "../Output";
 type EnumStyle = "enum" | "type";
 
 const makeMapper =
-  (style: EnumStyle, config: InstantiatedConfig) =>
+  (style: EnumStyle) =>
   (
     enumDetails: EnumDetails,
   ): { path: Path; declaration: Declaration } | undefined => {
+    const { instantiatedConfig } = useKanelContext();
+
     // If an enum has a @type tag in the comment,
     // we will use that type instead of a generated one.
     const { tags } = tryParse(enumDetails.comment);
@@ -24,10 +26,10 @@ const makeMapper =
       return undefined;
     }
 
-    const { name, comment, path } = config.getMetadata(
+    const { name, comment, path } = instantiatedConfig.getMetadata(
       enumDetails,
       undefined,
-      config,
+      instantiatedConfig,
     );
 
     if (style === "type") {
@@ -54,24 +56,23 @@ const makeMapper =
     }
   };
 
-const makeEnumsGenerator =
-  (config: InstantiatedConfig) =>
-  (schema: Schema, outputAcc: Output): Output => {
-    const declarations =
-      schema.enums?.map(makeMapper(config.enumStyle, config)) ?? [];
-    return declarations.reduce((acc, elem) => {
-      if (elem === undefined) return acc;
-      const { path, declaration } = elem;
-      const existing = acc[path];
-      if (existing) {
-        existing.declarations.push(declaration);
-      } else {
-        acc[path] = {
-          declarations: [declaration],
-        };
-      }
-      return acc;
-    }, outputAcc);
-  };
+const enumsGenerator = (schema: Schema, outputAcc: Output): Output => {
+  const { instantiatedConfig } = useKanelContext();
+  const declarations =
+    schema.enums?.map(makeMapper(instantiatedConfig.enumStyle)) ?? [];
+  return declarations.reduce((acc, elem) => {
+    if (elem === undefined) return acc;
+    const { path, declaration } = elem;
+    const existing = acc[path];
+    if (existing) {
+      existing.declarations.push(declaration);
+    } else {
+      acc[path] = {
+        declarations: [declaration],
+      };
+    }
+    return acc;
+  }, outputAcc);
+};
 
-export default makeEnumsGenerator;
+export default enumsGenerator;

--- a/packages/kanel/src/render.test.ts
+++ b/packages/kanel/src/render.test.ts
@@ -1,5 +1,6 @@
-import { describe, expect, it, vi } from "vitest";
+import { beforeEach, describe, expect, it, vi } from "vitest";
 
+import { createTestContext, runWithContextSync } from "./context";
 import type { InstantiatedConfig } from "./config-types";
 import type { Declaration } from "./declaration-types";
 import render from "./render";
@@ -20,6 +21,12 @@ const instantiatedConfig: InstantiatedConfig = {
 };
 
 describe("processGenerationSetup", () => {
+  let testContext: ReturnType<typeof createTestContext>;
+
+  beforeEach(() => {
+    testContext = createTestContext(instantiatedConfig);
+  });
+
   it("should process a type declaration", () => {
     const declarations: Declaration[] = [
       {
@@ -30,7 +37,9 @@ describe("processGenerationSetup", () => {
         typeDefinition: ["string"],
       },
     ];
-    const lines = render(declarations, "./", instantiatedConfig);
+    const lines = runWithContextSync(testContext, () =>
+      render(declarations, "./"),
+    );
     expect(lines).toEqual([
       "/** This is just a string */",
       `export type MyString = string;`,
@@ -47,7 +56,9 @@ describe("processGenerationSetup", () => {
         typeDefinition: ["", "| 'apples'", "| 'oranges'", "| 'bananas'"],
       },
     ];
-    const lines = render(declarations, "./", instantiatedConfig);
+    const lines = runWithContextSync(testContext, () =>
+      render(declarations, "./"),
+    );
     expect(lines).toEqual([
       `export type MyUnion = `,
       `  | 'apples'`,
@@ -74,7 +85,9 @@ describe("processGenerationSetup", () => {
         ],
       },
     ];
-    const lines = render(declarations, "./", instantiatedConfig);
+    const lines = runWithContextSync(testContext, () =>
+      render(declarations, "./"),
+    );
     expect(lines).toEqual([
       `export default interface Member {`,
       "  /**",
@@ -95,7 +108,9 @@ describe("processGenerationSetup", () => {
         values: ["G", "PG", "PG-13", "R", "NC-17"],
       },
     ];
-    const lines = render(declarations, "./", instantiatedConfig);
+    const lines = runWithContextSync(testContext, () =>
+      render(declarations, "./"),
+    );
     expect(lines).toEqual([
       `export enum MpaaRating {`,
       `  G = 'G',`,
@@ -116,7 +131,9 @@ describe("processGenerationSetup", () => {
         values: ["apples", "oranges", "bananas"],
       },
     ];
-    const lines = render(declarations, "./", instantiatedConfig);
+    const lines = runWithContextSync(testContext, () =>
+      render(declarations, "./"),
+    );
     expect(lines).toEqual([
       `enum Fruit {`,
       `  apples = 'apples',`,
@@ -138,7 +155,9 @@ describe("processGenerationSetup", () => {
         value: "true",
       },
     ];
-    const lines = render(declarations, "./", instantiatedConfig);
+    const lines = runWithContextSync(testContext, () =>
+      render(declarations, "./"),
+    );
     expect(lines).toEqual([`export const MyConstant: boolean = true;`]);
   });
 
@@ -152,7 +171,9 @@ describe("processGenerationSetup", () => {
         value: ["z.object({", "  actor_id: actorId,", "})"],
       },
     ];
-    const lines = render(declarations, "./", instantiatedConfig);
+    const lines = runWithContextSync(testContext, () =>
+      render(declarations, "./"),
+    );
     expect(lines).toEqual([
       "export const actor: z.Schema<Actor> = z.object({",
       `  actor_id: actorId,`,
@@ -172,7 +193,9 @@ describe("processGenerationSetup", () => {
         ],
       },
     ];
-    const lines = render(declarations, "./", instantiatedConfig);
+    const lines = runWithContextSync(testContext, () =>
+      render(declarations, "./"),
+    );
     expect(lines).toEqual([
       "/**",
       " * This is a // * /* comment *\\/",

--- a/packages/kanel/src/render.ts
+++ b/packages/kanel/src/render.ts
@@ -1,4 +1,4 @@
-import type { InstantiatedConfig } from "./config-types";
+import { useKanelContext } from "./context";
 import type { Declaration } from "./declaration-types";
 import escapeComment from "./escapeComment";
 import escapeFieldName from "./escapeFieldName";
@@ -161,12 +161,12 @@ const processDeclaration = (
   return declarationLines;
 };
 
-const render = (
-  declarations: Declaration[],
-  outputPath: string,
-  config: InstantiatedConfig,
-): string[] => {
-  const importGenerator = new ImportGenerator(outputPath, config);
+const render = (declarations: Declaration[], outputPath: string): string[] => {
+  const { instantiatedConfig } = useKanelContext();
+  const importGenerator = new ImportGenerator(
+    outputPath,
+    instantiatedConfig.importsExtension,
+  );
   const lines: string[] = [];
 
   declarations.forEach((declaration, index) => {


### PR DESCRIPTION
Refactoring that prepares the code for v4. Replaces the passing of an instantiated configuration to just about every function in the library with an async localstorage. 