### PR TITLE
fix(kanel-zod): respect provided enum type through top level config

### DIFF
--- a/packages/kanel-zod/src/processEnum.ts
+++ b/packages/kanel-zod/src/processEnum.ts
@@ -19,13 +19,10 @@ const processEnum = (
     "selector",
     instantiatedConfig,
   );
-  const lines: string[] = instantiatedConfig.enumStyle === "type" ? [
-    `z.enum([`,
-    ...e.values.map((v) => `  '${v}',`),
-    "])",
-  ] : [
-    `z.enum(${typescriptTypeName})`
-  ];
+  const lines: string[] =
+    instantiatedConfig.enumStyle === "type"
+      ? [`z.enum([`, ...e.values.map((v) => `  '${v}',`), "])"]
+      : [`z.enum(${typescriptTypeName})`];
   const declaration: ConstantDeclaration = {
     declarationType: "constant",
     comment: [`Zod schema for ${e.name}`],


### PR DESCRIPTION
This fixes generated enum zod schema when enumStyle === "enum" in the top level config.

Currently when enumStyle is configured to "enum", the generator creates a zod schema using an array of string literals (`z.enum([...])`). This results in a return type of a union of string literals, which is not assignable to the generated typescript enum type without manual casting.

This makes the schema more compatible with the generated type.

Before:

```Typescript
import { z } from "zod";

/** Represents the enum public.some_enum */
export enum SomeEnum {
  Member1 = "Member1",
  Member2 = "Member2",
  Member3 = "Member3",
  Member4 = "Member4",
  Member5 = "Member5",
}

export default SomeEnum;

/** Zod schema for some_enum */
export const someEnumSchema = z.enum([
  "Member1",
  "Member2",
  "Member3",
  "Member4",
  "Member5",
]);
```

With the above generated code this would fail:

```Typescript
// Type '"Member_1" | "Member_2" | "Member_3" | "Member_4" | "Member_5"' is not assignable to type 'SomeEnum'.
// Type '"Member_1"' is not assignable to type 'SomeEnum'. Did you mean 'SomeEnum.Member1'?
const parsed: SomeEnum = someEnumSchema.parse("Member1");
```

After:

```Typescript
```Typescript
import { z } from "zod";

/** Represents the enum public.some_enum */
export enum SomeEnum  {
  Member1 = 'Member1',
  Member2 = 'Member2',
  Member3 = 'Member3',
  Member4 = 'Member4',
  Member5 = 'Member5',
};

export default SomeEnum;

/** Zod schema for some_enum */
export const someEnumSchema = z.enum(SomeEnum);
```