### PR TITLE
docs: add pglite dependency analysis documentation

### DIFF
--- a/docs-src/pglite-dependency-analysis.md
+++ b/docs-src/pglite-dependency-analysis.md
@@ -1,0 +1,40 @@
+# Pglite Dependency Analysis
+
+## Summary
+
+This document records the analysis of `@electric-sql/pglite` and `knex-pglite` dependencies in the kanel monorepo.
+
+## Findings
+
+### Direct Dependencies
+**None.** Neither `@electric-sql/pglite` nor `knex-pglite` appear as direct dependencies in any package.json file:
+
+- `packages/kanel/package.json` - No pglite references
+- `packages/kanel-knex/package.json` - Only depends on `knex: ^3.0.0`
+- `packages/kanel-kysely/package.json` - No pglite references
+- `packages/kanel-seeder/package.json` - No pglite references
+- `packages/kanel-zod/package.json` - No pglite references
+- `packages/kanel-enum-tables/package.json` - Only depends on `knex: ^3.0.0`
+
+### Transitive Dependencies
+`@electric-sql/pglite` and `knex-pglite` appear in `package-lock.json` as **transitive dependencies** of `extract-pg-schema`:
+
+```
+extract-pg-schema@5.8.1 (devDependency of kanel-knex)
+  └── knex-pglite@^0.12.0
+        └── @electric-sql/pglite@0.x (peer dependency)
+```
+
+### Code Imports
+**No imports of `@electric-sql/pglite` were found anywhere in the codebase.**
+
+A grep search across all `.ts`, `.js`, and `.json` files confirmed:
+- No `import` statements referencing `@electric-sql/pglite`
+- No `require` statements referencing `@electric-sql/pglite`
+- No direct usage of pglite in any source code
+
+## Implications
+
+1. The kanel packages do not directly support or depend on pglite
+2. Any pglite support would need to be added explicitly as a new feature
+3. The transitive dependency exists only for testing purposes (via `extract-pg-schema`)


### PR DESCRIPTION
## Summary

This PR adds documentation analyzing the  and  dependencies in the kanel monorepo.

## Findings

### Direct Dependencies
**None.** Neither  nor  appear as direct dependencies in any package.json file:

-  - No pglite references
-  - Only depends on 
-  - No pglite references
-  - No pglite references
-  - No pglite references
-  - Only depends on 

### Transitive Dependencies
 and  appear in  as **transitive dependencies** of :



### Code Imports
**No imports of  were found anywhere in the codebase.**

A grep search across all , , and  files confirmed:
- No  statements referencing 
- No  statements referencing 
- No direct usage of pglite in any source code

## Implications

1. The kanel packages do not directly support or depend on pglite
2. Any pglite support would need to be added explicitly as a new feature
3. The transitive dependency exists only for testing purposes (via )