### PR TITLE
fix(kanel-zod): respect provided enum type through top level config

### DIFF
--- a/packages/kanel-zod/src/processEnum.ts
+++ b/packages/kanel-zod/src/processEnum.ts
@@ -1,5 +1,6 @@
 import type { EnumDetails } from "extract-pg-schema";
 import type { ConstantDeclaration, PgTsGeneratorContext } from "kanel";
+import { useKanelContext } from "kanel";
 
 import type { GetZodSchemaMetadata } from "./GenerateZodSchemasConfig";
 import zImport from "./zImport";
@@ -10,11 +11,11 @@ const processEnum = (
   context: PgTsGeneratorContext,
 ): ConstantDeclaration => {
   const { name } = getZodSchemaMetadata(e, undefined, context);
-  const lines: string[] = [
-    `z.enum([`,
-    ...e.values.map((v) => `  '${v}',`),
-    "])",
-  ];
+  const { enumStyle } = useKanelContext().typescriptConfig;
+  const lines: string[] =
+    enumStyle === "literal-union"
+      ? [`z.enum([`, ...e.values.map((v) => `  '${v}',`), "])"]
+      : [`z.enum(${context.getMetadata(e, undefined).name})`];
 
   const declaration: ConstantDeclaration = {
     declarationType: "constant",


### PR DESCRIPTION
This re-applies the fix from #728, which was merged but has since been dropped. The current `processEnum.ts` no longer branches on the enum style and always emits an array of string literals.

This fixes the generated enum zod schema when the enum style is `"enum"` (the default). In that mode the generator emits a real TypeScript enum, but the zod schema was still built from an array of string literals (`z.enum([...])`). That produces a union of string literals, which is not assignable to the generated enum type without manual casting.

Referencing the emitted enum directly makes the schema compatible with the generated type. When the enum style is `"literal-union"` there is no enum object to reference, so the string-literal array is kept.

The style is read from `useKanelContext().typescriptConfig`, the same source `enumsGenerator` uses to decide the emitted shape, and the enum name comes from `context.getMetadata(e, undefined)`, so the schema always matches the model.

Before (enum style):

```Typescript
import { z } from "zod";

/** Represents the enum public.some_enum */
export enum SomeEnum {
  Member1 = "Member1",
  Member2 = "Member2",
  Member3 = "Member3",
}

export default SomeEnum;

/** Zod schema for some_enum */
export const someEnumSchema = z.enum([
  "Member1",
  "Member2",
  "Member3",
]);
```

With the above generated code this fails:

```Typescript
// Type '"Member1" | "Member2" | "Member3"' is not assignable to type 'SomeEnum'.
// Type '"Member1"' is not assignable to type 'SomeEnum'. Did you mean 'SomeEnum.Member1'?
const parsed: SomeEnum = someEnumSchema.parse("Member1");
```

After (enum style):

```Typescript
import { z } from "zod";

/** Represents the enum public.some_enum */
export enum SomeEnum {
  Member1 = 'Member1',
  Member2 = 'Member2',
  Member3 = 'Member3',
}

export default SomeEnum;

/** Zod schema for some_enum */
export const someEnumSchema = z.enum(SomeEnum);
```

Verified end to end against the `ts-plus-zod` example DB: `enumStyle: "literal-union"` output is unchanged, `enumStyle: "enum"` now emits `z.enum(SomeEnum)`, and the generated enum-style code typechecks against zod 4 (the assignment above compiles).
