### PR TITLE
Resolve view sources by schema and name, and through nested views

### DIFF
--- a/packages/kanel/src/generators/generateProperties.ts
+++ b/packages/kanel/src/generators/generateProperties.ts
@@ -31,7 +31,9 @@ const generateProperties = <D extends CompositeDetails>(
       // intermediate views -- to see whether it is nullable.
       if (config.resolveViews !== false && hasSource(p)) {
         const origin = findOriginColumn(p.source, details, schemas);
-        if (origin) {
+        // A foreign table only reports nullability once it has been resolved,
+        // so leave our own value alone rather than overwriting it with nothing.
+        if (origin?.column.isNullable !== undefined) {
           p.isNullable = origin.column.isNullable;
         }
       }

--- a/packages/kanel/src/generators/generateProperties.ts
+++ b/packages/kanel/src/generators/generateProperties.ts
@@ -1,11 +1,3 @@
-import type {
-  MaterializedViewColumn,
-  MaterializedViewDetails,
-  TableColumn,
-  TableDetails,
-  ViewColumn,
-  ViewDetails,
-} from "extract-pg-schema";
 import * as R from "ramda";
 
 import { useKanelContext } from "../context";
@@ -14,6 +6,7 @@ import type { InterfacePropertyDeclaration } from "../ts-utilities/ts-declaratio
 import type TypeImport from "../ts-utilities/TypeImport";
 import type { CompositeDetails, CompositeProperty } from "./composite-types";
 import resolveType from "./resolveType";
+import { findOriginColumn, hasSource } from "./resolveViewSource";
 
 const generateProperties = <D extends CompositeDetails>(
   details: D,
@@ -33,25 +26,13 @@ const generateProperties = <D extends CompositeDetails>(
   const result: InterfacePropertyDeclaration[] = sortedPs
     .filter((p) => generateFor === "selector" || p.generated !== "ALWAYS")
     .map((p: CompositeProperty): InterfacePropertyDeclaration => {
-      // If this is a (materialized or not) view column, we need to check
-      // the source table to see if the column is nullable.
-      if (
-        config.resolveViews !== false &&
-        (p as ViewColumn | MaterializedViewColumn).source
-      ) {
-        const source = (p as ViewColumn | MaterializedViewColumn).source;
-        const target: TableDetails | ViewDetails | MaterializedViewDetails =
-          schemas[source.schema].tables.find((t) => t.name === source.table);
-
-        if (target) {
-          const column = (
-            target.columns as Array<
-              TableColumn | ViewColumn | MaterializedViewColumn
-            >
-          ).find((c) => c.name === source.column);
-          if (column) {
-            p.isNullable = column.isNullable;
-          }
+      // If this is a (materialized or not) view column, we need to follow it
+      // back to the column it originates from -- possibly through several
+      // intermediate views -- to see whether it is nullable.
+      if (config.resolveViews !== false && hasSource(p)) {
+        const origin = findOriginColumn(p.source, details, schemas);
+        if (origin) {
+          p.isNullable = origin.column.isNullable;
         }
       }
 

--- a/packages/kanel/src/generators/resolveType.ts
+++ b/packages/kanel/src/generators/resolveType.ts
@@ -14,6 +14,7 @@ import { usePgTsGeneratorContext } from "./pgTsGeneratorContext";
 import type Details from "../Details";
 import type TypeDefinition from "../ts-utilities/TypeDefinition";
 import type { CompositeDetails, CompositeProperty } from "./composite-types";
+import { findSourceRelation, hasSource } from "./resolveViewSource";
 
 const getColumnFromReference = (
   reference: ColumnReference,
@@ -140,43 +141,9 @@ const resolveType = (
     }
     // 3) If this is a view with a source (i.e. the table that it's based on),
     // get the type from the source.
-    if (
-      config.resolveViews !== false &&
-      (c as ViewColumn | MaterializedViewColumn).source
-    ) {
-      const source = (c as ViewColumn | MaterializedViewColumn).source;
-      let target: TableDetails | ViewDetails | MaterializedViewDetails =
-        schemas[source.schema].tables.find((t) => t.name === source.table);
-
-      if (!target) {
-        target = schemas[source.schema].views.find(
-          (v) =>
-            v.name === source.table &&
-            v.name !== (d as ViewDetails).informationSchemaValue.table_name,
-        );
-      }
-      if (!target) {
-        target = schemas[source.schema].materializedViews.find(
-          (v) => v.name === source.table,
-        );
-      }
-      if (!target) {
-        target = schemas["public"]?.tables?.find(
-          (t) => t.name === source.table,
-        );
-      }
-      if (!target) {
-        target = schemas["public"]?.views?.find(
-          (v) =>
-            v.name === source.table &&
-            v.name !== (d as ViewDetails).informationSchemaValue.table_name,
-        );
-      }
-      if (!target) {
-        target = schemas["public"]?.materializedViews?.find(
-          (v) => v.name === source.table,
-        );
-      }
+    if (config.resolveViews !== false && hasSource(c)) {
+      const source = c.source;
+      const target = findSourceRelation(source, d, schemas);
 
       if (!target) {
         console.warn("Could not resolve source", source);
@@ -184,11 +151,7 @@ const resolveType = (
         return "unknown";
       }
 
-      const column = (
-        target.columns as Array<
-          TableColumn | ViewColumn | MaterializedViewColumn
-        >
-      ).find((c) => c.name === source.column);
+      const column = target.columns.find((col) => col.name === source.column);
 
       if (column) {
         return resolveType(

--- a/packages/kanel/src/generators/resolveViewSource.pipeline.test.ts
+++ b/packages/kanel/src/generators/resolveViewSource.pipeline.test.ts
@@ -1,0 +1,79 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+import crossSchemaViews from "../mocks/crossSchemaViews";
+import processDatabase from "../processDatabase";
+
+vi.mock("extract-pg-schema", () => ({ extractSchemas: vi.fn() }));
+vi.mock("../writeFile", () => ({ default: vi.fn() }));
+
+import { extractSchemas } from "extract-pg-schema";
+import writeFile from "../writeFile";
+
+const mockedWriteFile = vi.mocked(writeFile);
+
+function getResults(): { [fullPath: string]: string[] } {
+  return mockedWriteFile.mock.calls.reduce(
+    (acc, [args]) => {
+      acc[args.fullPath] = args.lines;
+      return acc;
+    },
+    {} as Record<string, string[]>,
+  );
+}
+
+/**
+ * Runs the real generator pipeline over a static schema fixture, so the
+ * rendered output can be asserted without a database. See
+ * `mocks/crossSchemaViews.ts` for the shape being modelled.
+ */
+describe("Generating from same-named views across schemas", () => {
+  beforeEach(async () => {
+    mockedWriteFile.mockClear();
+    vi.mocked(extractSchemas).mockResolvedValue(crossSchemaViews as any);
+
+    await processDatabase({
+      connection: {},
+      outputPath: "./models",
+      preDeleteOutputFolder: false,
+      resolveViews: true,
+    });
+  });
+
+  it("carries nullability from the originating table through both views", () => {
+    const result = getResults();
+    expect(result["models/api/Accounts.ts"]).toEqual(
+      expect.arrayContaining([
+        "  required_name: string;",
+        "  optional_name: string | null;",
+      ]),
+    );
+  });
+
+  it("keeps resolving through a further hop inside the same schema", () => {
+    const result = getResults();
+    expect(result["models/api/AccountsDetails.ts"]).toEqual(
+      expect.arrayContaining([
+        "  id: public_AccountRecordsId;",
+        "  required_name: string;",
+        "  optional_name: string | null;",
+      ]),
+    );
+  });
+
+  it("skips a same-named relation that does not carry the column", () => {
+    const result = getResults();
+    expect(result["models/api/AccountSecrets.ts"]).toEqual(
+      expect.arrayContaining(["  secret: string | null;"]),
+    );
+  });
+
+  it("resolves the identifier type through both views", () => {
+    const result = getResults();
+    expect(result["models/api/Accounts.ts"]).toEqual(
+      expect.arrayContaining([
+        "  id: public_AccountRecordsId;",
+        "import type { AccountRecordsId as public_AccountRecordsId } from '../public/AccountRecords';",
+      ]),
+    );
+  });
+});

--- a/packages/kanel/src/generators/resolveViewSource.pipeline.test.ts
+++ b/packages/kanel/src/generators/resolveViewSource.pipeline.test.ts
@@ -67,6 +67,16 @@ describe("Generating from same-named views across schemas", () => {
     );
   });
 
+  it("keeps its own nullability when the origin reports none", () => {
+    const result = getResults();
+    expect(result["models/api/Ledger.ts"]).toEqual(
+      expect.arrayContaining([
+        "  memo: string | null;",
+        "  note: string | null;",
+      ]),
+    );
+  });
+
   it("resolves the identifier type through both views", () => {
     const result = getResults();
     expect(result["models/api/Accounts.ts"]).toEqual(

--- a/packages/kanel/src/generators/resolveViewSource.test.ts
+++ b/packages/kanel/src/generators/resolveViewSource.test.ts
@@ -1,0 +1,147 @@
+import { describe, expect, it } from "vitest";
+import type { Schema, ViewDetails } from "extract-pg-schema";
+
+import crossSchemaViews, {
+  accountRecords,
+  apiAccounts,
+  apiAccountsDetails,
+  apiSecrets,
+  publicAccounts,
+} from "../mocks/crossSchemaViews";
+import { findOriginColumn, findSourceRelation } from "./resolveViewSource";
+
+const sourceOf = (view: ViewDetails, columnName: string) => {
+  const column = view.columns.find((c) => c.name === columnName);
+  if (!column?.source) {
+    throw new Error(`${view.name}.${columnName} has no source`);
+  }
+  return column.source;
+};
+
+/**
+ * A view that feeds itself, and a pair that feed each other. Neither shape is
+ * representative enough to belong in the shared fixture, but both have to
+ * terminate rather than recurse forever.
+ */
+const selfFeeding = {
+  name: "loop",
+  schemaName: "api",
+  kind: "view",
+  columns: [
+    { name: "id", source: { schema: "api", table: "loop", column: "id" } },
+  ],
+} as unknown as ViewDetails;
+
+const pingPong = ["ping", "pong"].map(
+  (name, index) =>
+    ({
+      name,
+      schemaName: "api",
+      kind: "view",
+      columns: [
+        {
+          name: "id",
+          source: {
+            schema: "api",
+            table: index === 0 ? "pong" : "ping",
+            column: "id",
+          },
+        },
+      ],
+    }) as unknown as ViewDetails,
+);
+
+const withViews = (views: ViewDetails[]): Record<string, Schema> => ({
+  ...crossSchemaViews,
+  api: { ...crossSchemaViews.api, views },
+});
+
+describe("findSourceRelation", () => {
+  it("finds a same-named view in another schema", () => {
+    const source = sourceOf(apiAccounts, "id");
+    expect(findSourceRelation(source, apiAccounts, crossSchemaViews)).toBe(
+      publicAccounts,
+    );
+  });
+
+  it("finds the table a view selects from", () => {
+    const source = sourceOf(publicAccounts, "id");
+    expect(findSourceRelation(source, publicAccounts, crossSchemaViews)).toBe(
+      accountRecords,
+    );
+  });
+
+  it("skips a relation that refers to itself", () => {
+    const source = sourceOf(selfFeeding, "id");
+    const schemas = withViews([selfFeeding]);
+    expect(findSourceRelation(source, selfFeeding, schemas)).toBeUndefined();
+  });
+
+  it("skips a same-named relation that does not carry the column", () => {
+    const source = sourceOf(apiSecrets, "secret");
+    expect(source.schema).toBe("api");
+    expect(findSourceRelation(source, apiSecrets, crossSchemaViews)).toBe(
+      accountRecords,
+    );
+  });
+
+  it("falls back to public when the source schema has no match", () => {
+    const source = { schema: "reporting", table: "accounts", column: "id" };
+    expect(findSourceRelation(source, apiAccounts, crossSchemaViews)).toBe(
+      publicAccounts,
+    );
+  });
+
+  it("returns undefined for an unknown schema rather than throwing", () => {
+    const source = { schema: "nope", table: "missing", column: "id" };
+    expect(
+      findSourceRelation(source, apiAccounts, crossSchemaViews),
+    ).toBeUndefined();
+  });
+});
+
+describe("findOriginColumn", () => {
+  it("follows a same-named chain to the originating table column", () => {
+    const origin = findOriginColumn(
+      sourceOf(apiAccounts, "optional_name"),
+      apiAccounts,
+      crossSchemaViews,
+    );
+    expect(origin?.details).toBe(accountRecords);
+    expect(origin?.column).toBe(
+      accountRecords.columns.find((c) => c.name === "optional_name"),
+    );
+  });
+
+  it("follows a chain that crosses schemas and then stays within one", () => {
+    const origin = findOriginColumn(
+      sourceOf(apiAccountsDetails, "optional_name"),
+      apiAccountsDetails,
+      crossSchemaViews,
+    );
+    expect(origin?.details).toBe(accountRecords);
+    expect(origin?.column.isNullable).toBe(true);
+  });
+
+  it("returns undefined when the chain cannot be followed", () => {
+    const source = { schema: "public", table: "accounts", column: "gone" };
+    expect(
+      findOriginColumn(source, apiAccounts, crossSchemaViews),
+    ).toBeUndefined();
+  });
+
+  it("terminates on a view that feeds itself", () => {
+    const schemas = withViews([selfFeeding]);
+    expect(
+      findOriginColumn(sourceOf(selfFeeding, "id"), selfFeeding, schemas),
+    ).toBeUndefined();
+  });
+
+  it("terminates on views that feed each other", () => {
+    const [ping, pong] = pingPong;
+    const schemas = withViews([ping, pong]);
+    expect(
+      findOriginColumn(sourceOf(ping, "id"), ping, schemas),
+    ).toBeUndefined();
+  });
+});

--- a/packages/kanel/src/generators/resolveViewSource.test.ts
+++ b/packages/kanel/src/generators/resolveViewSource.test.ts
@@ -5,10 +5,15 @@ import crossSchemaViews, {
   accountRecords,
   apiAccounts,
   apiAccountsDetails,
+  apiLedger,
   apiSecrets,
+  externalLedger,
   publicAccounts,
 } from "../mocks/crossSchemaViews";
 import { findOriginColumn, findSourceRelation } from "./resolveViewSource";
+import generateProperties from "./generateProperties";
+import { createTestContext, runWithContextSync } from "../context";
+import { runWithPgTsGeneratorContextSync } from "./pgTsGeneratorContext";
 
 const sourceOf = (view: ViewDetails, columnName: string) => {
   const column = view.columns.find((c) => c.name === columnName);
@@ -41,6 +46,8 @@ const pingPong = ["ping", "pong"].map(
       columns: [
         {
           name: "id",
+          type: { fullName: "pg_catalog.int4", kind: "base" },
+          isNullable: true,
           source: {
             schema: "api",
             table: index === 0 ? "pong" : "ping",
@@ -55,6 +62,31 @@ const withViews = (views: ViewDetails[]): Record<string, Schema> => ({
   ...crossSchemaViews,
   api: { ...crossSchemaViews.api, views },
 });
+
+/** Same harness as resolveViews.test.ts, for the cases that need a context. */
+const withContext = (schemas: Record<string, Schema>, fn: () => void) => {
+  const config = {
+    schemas,
+    typeMap: { "pg_catalog.int4": "number" },
+    resolveViews: true,
+    getMetadata: () => ({ name: "X", path: "x" }),
+    getPropertyMetadata: (p: { name: string }) => ({
+      name: p.name,
+      comment: [],
+    }),
+  } as any;
+
+  runWithContextSync(createTestContext(config), () =>
+    runWithPgTsGeneratorContextSync(
+      {
+        typeMap: config.typeMap,
+        getMetadata: config.getMetadata,
+        getPropertyMetadata: config.getPropertyMetadata,
+      } as any,
+      fn,
+    ),
+  );
+};
 
 describe("findSourceRelation", () => {
   it("finds a same-named view in another schema", () => {
@@ -75,6 +107,13 @@ describe("findSourceRelation", () => {
     const source = sourceOf(selfFeeding, "id");
     const schemas = withViews([selfFeeding]);
     expect(findSourceRelation(source, selfFeeding, schemas)).toBeUndefined();
+  });
+
+  it("resolves a foreign table as a source", () => {
+    const source = sourceOf(apiLedger, "memo");
+    expect(findSourceRelation(source, apiLedger, crossSchemaViews)).toBe(
+      externalLedger,
+    );
   });
 
   it("skips a same-named relation that does not carry the column", () => {
@@ -143,5 +182,25 @@ describe("findOriginColumn", () => {
     expect(
       findOriginColumn(sourceOf(ping, "id"), ping, schemas),
     ).toBeUndefined();
+  });
+});
+
+describe("nullability when the origin cannot be adopted", () => {
+  it("keeps the column's own value when the chain cannot be followed", () => {
+    const [ping, pong] = pingPong;
+    const schemas = withViews([ping, pong]);
+
+    withContext(schemas, () => {
+      const props = generateProperties(ping, "selector");
+      expect(props[0].isNullable).toBe(true);
+    });
+  });
+
+  it("keeps the column's own value when the origin reports none", () => {
+    withContext(crossSchemaViews, () => {
+      const props = generateProperties(apiLedger, "selector");
+      const note = props.find((p) => p.name === "note");
+      expect(note?.isNullable).toBe(true);
+    });
   });
 });

--- a/packages/kanel/src/generators/resolveViewSource.ts
+++ b/packages/kanel/src/generators/resolveViewSource.ts
@@ -1,0 +1,132 @@
+import type {
+  MaterializedViewColumn,
+  MaterializedViewDetails,
+  Schema,
+  TableColumn,
+  TableDetails,
+  ViewColumn,
+  ViewDetails,
+} from "extract-pg-schema";
+
+import type { CompositeDetails, CompositeProperty } from "./composite-types";
+
+/** A relation that a view column can originate from. */
+export type SourceRelation =
+  | TableDetails
+  | ViewDetails
+  | MaterializedViewDetails;
+
+type SourceColumn = TableColumn | ViewColumn | MaterializedViewColumn;
+
+/** The link extract-pg-schema records from a view column to its origin. */
+export type ViewSource = NonNullable<ViewColumn["source"]>;
+
+export type ColumnOrigin = {
+  column: SourceColumn;
+  details: SourceRelation;
+};
+
+/**
+ * Narrows to a column that extract-pg-schema was able to trace back to a
+ * relation -- a view, materialized view or foreign table column.
+ */
+export const hasSource = (
+  column: CompositeProperty,
+): column is CompositeProperty & { source: ViewSource } =>
+  "source" in column && column.source != null;
+
+/**
+ * A relation is only *itself* when both its schema and its name match. Testing
+ * the name alone would discard a legitimate same-named relation in a different
+ * schema, which is a common pattern for API layers built as thin wrappers
+ * (`api.users` selecting from `public.users`).
+ */
+const isSelfReference = (
+  relation: SourceRelation,
+  details: CompositeDetails,
+): boolean =>
+  relation.name === details.name && relation.schemaName === details.schemaName;
+
+/**
+ * A candidate has to actually carry the column being looked for. An
+ * unqualified relation is recorded against the view's own schema, so
+ * `select instructions from accounts` inside `api.accounts_lite` arrives as
+ * `api.accounts` -- a real, same-named relation that may well be a curated
+ * view which omits that column. Only the relation that has it can be the
+ * source.
+ */
+const carriesColumn = (
+  relation: SourceRelation,
+  source: ViewSource,
+): boolean => {
+  const columns: SourceColumn[] = relation.columns;
+  return columns.some((c) => c.name === source.column);
+};
+
+const findInSchema = (
+  schema: Schema | undefined,
+  source: ViewSource,
+  details: CompositeDetails,
+): SourceRelation | undefined =>
+  [
+    ...(schema?.tables ?? []),
+    ...(schema?.views ?? []),
+    ...(schema?.materializedViews ?? []),
+  ].find(
+    (relation) =>
+      relation.name === source.table &&
+      !isSelfReference(relation, details) &&
+      carriesColumn(relation, source),
+  );
+
+/**
+ * Find the relation that a view column's source points at. An unqualified
+ * relation in a view definition is recorded against the view's own schema, so
+ * fall back to `public` the way the default search_path would.
+ */
+export const findSourceRelation = (
+  source: ViewSource,
+  details: CompositeDetails,
+  schemas: Record<string, Schema>,
+): SourceRelation | undefined =>
+  findInSchema(schemas[source.schema], source, details) ??
+  findInSchema(schemas["public"], source, details);
+
+/**
+ * Follow a source link to the column it ultimately originates from, stepping
+ * through any number of intermediate views.
+ *
+ * Returns undefined when the chain cannot be followed all the way -- a missing
+ * relation or column, or a view that (directly or indirectly) feeds itself.
+ * Callers should then keep whatever value they already have rather than adopt
+ * a half-resolved one.
+ *
+ * Each step either stops or records the column it stepped onto in `seen`, and
+ * a set of schemas holds finitely many columns, so the recursion terminates.
+ */
+export const findOriginColumn = (
+  source: ViewSource,
+  details: CompositeDetails,
+  schemas: Record<string, Schema>,
+  seen: ReadonlySet<CompositeProperty> = new Set(),
+): ColumnOrigin | undefined => {
+  const relation = findSourceRelation(source, details, schemas);
+  const column = relation?.columns.find((c) => c.name === source.column);
+  if (!relation || !column) {
+    return undefined;
+  }
+
+  if (!hasSource(column)) {
+    return { column, details: relation };
+  }
+  if (seen.has(column)) {
+    return undefined;
+  }
+
+  return findOriginColumn(
+    column.source,
+    relation,
+    schemas,
+    new Set(seen).add(column),
+  );
+};

--- a/packages/kanel/src/generators/resolveViewSource.ts
+++ b/packages/kanel/src/generators/resolveViewSource.ts
@@ -1,4 +1,6 @@
 import type {
+  ForeignTableColumn,
+  ForeignTableDetails,
   MaterializedViewColumn,
   MaterializedViewDetails,
   Schema,
@@ -13,10 +15,15 @@ import type { CompositeDetails, CompositeProperty } from "./composite-types";
 /** A relation that a view column can originate from. */
 export type SourceRelation =
   | TableDetails
+  | ForeignTableDetails
   | ViewDetails
   | MaterializedViewDetails;
 
-type SourceColumn = TableColumn | ViewColumn | MaterializedViewColumn;
+type SourceColumn =
+  | TableColumn
+  | ForeignTableColumn
+  | ViewColumn
+  | MaterializedViewColumn;
 
 /** The link extract-pg-schema records from a view column to its origin. */
 export type ViewSource = NonNullable<ViewColumn["source"]>;
@@ -70,6 +77,7 @@ const findInSchema = (
 ): SourceRelation | undefined =>
   [
     ...(schema?.tables ?? []),
+    ...(schema?.foreignTables ?? []),
     ...(schema?.views ?? []),
     ...(schema?.materializedViews ?? []),
   ].find(

--- a/packages/kanel/src/mocks/AGENTS.md
+++ b/packages/kanel/src/mocks/AGENTS.md
@@ -1,3 +1,8 @@
 # mocks
 
-Static JSON schema fixtures for unit tests. `dvdrental.json` is a serialized `extract-pg-schema` result representing the PostgreSQL dvdrental demo database — used to test generators without a live database.
+Static schema fixtures for unit tests — serialized `extract-pg-schema` results, used to test generators without a live database.
+
+- `dvdrental.json` — the PostgreSQL dvdrental demo database.
+- `crossSchemaViews.ts` — a small schema where a curated schema exposes views that carry the same name as the relation they select from (`api.accounts` -> `public.accounts` -> `public.account_records`). Typed rather than JSON so the fixture is checked against `extract-pg-schema`'s types.
+
+Mock `extractSchemas` with one of these and call `processDatabase` to assert on rendered output.

--- a/packages/kanel/src/mocks/crossSchemaViews.ts
+++ b/packages/kanel/src/mocks/crossSchemaViews.ts
@@ -138,6 +138,56 @@ export const apiAccounts: ViewDetails = {
   informationSchemaValue: { table_schema: "api", table_name: "accounts" },
 } as any;
 
+/** A foreign table is a valid source too, and lives in its own schema list. */
+export const externalLedger = {
+  name: "ledger",
+  schemaName: "public",
+  kind: "foreignTable",
+  comment: null,
+  columns: [
+    { ...tableColumn("id", "pg_catalog.int4", false, true), source: null },
+    { ...tableColumn("memo", "pg_catalog.text", true), source: null },
+    /*
+     * A foreign table only reports nullability once it has been resolved, so
+     * `isNullable` is absent here on purpose -- adopting it would silently
+     * turn a nullable column non-null.
+     */
+    {
+      name: "note",
+      expandedType: "pg_catalog.text",
+      type: { fullName: "pg_catalog.text", kind: "base" },
+      comment: null,
+      defaultValue: null,
+      isArray: false,
+      generated: "NEVER",
+      references: [],
+      source: null,
+    },
+  ],
+  informationSchemaValue: { table_schema: "public", table_name: "ledger" },
+} as any;
+
+export const apiLedger: ViewDetails = {
+  name: "ledger",
+  schemaName: "api",
+  kind: "view",
+  comment: null,
+  definition: "select * from public.ledger",
+  columns: [
+    viewColumn("memo", "pg_catalog.text", {
+      schema: "public",
+      table: "ledger",
+      column: "memo",
+    }),
+    viewColumn("note", "pg_catalog.text", {
+      schema: "public",
+      table: "ledger",
+      column: "note",
+    }),
+  ],
+  informationSchemaValue: { table_schema: "api", table_name: "ledger" },
+} as any;
+
 /**
  * One more hop, this time within `api`. A reference to a relation in a schema
  * that is not on the search_path keeps its qualifier, so this arrives as a
@@ -228,12 +278,13 @@ const crossSchemaViews: Record<string, Schema> = {
     ...emptySchema,
     name: "public",
     tables: [accountRecords],
+    foreignTables: [externalLedger],
     views: [publicAccounts],
   },
   api: {
     ...emptySchema,
     name: "api",
-    views: [apiAccounts, apiAccountsDetails, apiRecords, apiSecrets],
+    views: [apiAccounts, apiAccountsDetails, apiLedger, apiRecords, apiSecrets],
   },
 };
 

--- a/packages/kanel/src/mocks/crossSchemaViews.ts
+++ b/packages/kanel/src/mocks/crossSchemaViews.ts
@@ -1,0 +1,240 @@
+import type { Schema, TableDetails, ViewDetails } from "extract-pg-schema";
+
+/**
+ * A serialized `extract-pg-schema` result modelling the pattern where a
+ * curated schema exposes views that carry the same name as the relation they
+ * select from:
+ *
+ *     public.account_records (table)
+ *       <- public.accounts (view)
+ *         <- api.accounts (view)
+ *           <- api.accounts_details (view)
+ *
+ * `api.accounts` and `public.accounts` share a name but are different
+ * relations, so both the type and the nullability have to survive a same-named
+ * hop, and then keep surviving one more hop within `api` to reach
+ * `account_records`.
+ */
+
+const emptySchema = {
+  domains: [],
+  enums: [],
+  ranges: [],
+  tables: [],
+  foreignTables: [],
+  views: [],
+  materializedViews: [],
+  compositeTypes: [],
+  functions: [],
+  procedures: [],
+};
+
+const tableColumn = (
+  name: string,
+  fullName: string,
+  isNullable: boolean,
+  isPrimaryKey = false,
+) => ({
+  name,
+  expandedType: fullName,
+  type: { fullName, kind: "base" },
+  comment: null,
+  defaultValue: null,
+  isArray: false,
+  isPrimaryKey,
+  isNullable,
+  isIdentity: false,
+  generated: "NEVER",
+  references: [],
+  indices: [],
+});
+
+const viewColumn = (
+  name: string,
+  fullName: string,
+  source: { schema: string; table: string; column: string },
+) => ({
+  name,
+  expandedType: fullName,
+  type: { fullName, kind: "base" },
+  comment: null,
+  defaultValue: null,
+  isArray: false,
+  isNullable: true,
+  isIdentity: false,
+  generated: "NEVER",
+  source,
+  references: [],
+});
+
+export const accountRecords: TableDetails = {
+  name: "account_records",
+  schemaName: "public",
+  kind: "table",
+  comment: null,
+  columns: [
+    tableColumn("id", "pg_catalog.int4", false, true),
+    tableColumn("required_name", "pg_catalog.text", false),
+    tableColumn("optional_name", "pg_catalog.text", true),
+    tableColumn("secret", "pg_catalog.text", true),
+  ],
+  indices: [],
+  informationSchemaValue: {
+    table_schema: "public",
+    table_name: "account_records",
+  },
+} as any;
+
+export const publicAccounts: ViewDetails = {
+  name: "accounts",
+  schemaName: "public",
+  kind: "view",
+  comment: null,
+  definition: "select * from public.account_records",
+  columns: [
+    viewColumn("id", "pg_catalog.int4", {
+      schema: "public",
+      table: "account_records",
+      column: "id",
+    }),
+    viewColumn("required_name", "pg_catalog.text", {
+      schema: "public",
+      table: "account_records",
+      column: "required_name",
+    }),
+    viewColumn("optional_name", "pg_catalog.text", {
+      schema: "public",
+      table: "account_records",
+      column: "optional_name",
+    }),
+  ],
+  informationSchemaValue: { table_schema: "public", table_name: "accounts" },
+} as any;
+
+/** Selects from the same-named `public.accounts`, not from itself. */
+export const apiAccounts: ViewDetails = {
+  name: "accounts",
+  schemaName: "api",
+  kind: "view",
+  comment: null,
+  definition: "select * from public.accounts",
+  columns: [
+    viewColumn("id", "pg_catalog.int4", {
+      schema: "public",
+      table: "accounts",
+      column: "id",
+    }),
+    viewColumn("required_name", "pg_catalog.text", {
+      schema: "public",
+      table: "accounts",
+      column: "required_name",
+    }),
+    viewColumn("optional_name", "pg_catalog.text", {
+      schema: "public",
+      table: "accounts",
+      column: "optional_name",
+    }),
+  ],
+  informationSchemaValue: { table_schema: "api", table_name: "accounts" },
+} as any;
+
+/**
+ * One more hop, this time within `api`. A reference to a relation in a schema
+ * that is not on the search_path keeps its qualifier, so this arrives as a
+ * genuine `api` source rather than an inferred one.
+ */
+export const apiAccountsDetails: ViewDetails = {
+  name: "accounts_details",
+  schemaName: "api",
+  kind: "view",
+  comment: null,
+  definition: "select * from api.accounts",
+  columns: [
+    viewColumn("id", "pg_catalog.int4", {
+      schema: "api",
+      table: "accounts",
+      column: "id",
+    }),
+    viewColumn("required_name", "pg_catalog.text", {
+      schema: "api",
+      table: "accounts",
+      column: "required_name",
+    }),
+    viewColumn("optional_name", "pg_catalog.text", {
+      schema: "api",
+      table: "accounts",
+      column: "optional_name",
+    }),
+  ],
+  informationSchemaValue: {
+    table_schema: "api",
+    table_name: "accounts_details",
+  },
+} as any;
+
+/**
+ * A curated view that deliberately omits `secret`, so it cannot be the source
+ * of a reference to that column even though it carries the right name.
+ */
+export const apiRecords: ViewDetails = {
+  name: "account_records",
+  schemaName: "api",
+  kind: "view",
+  comment: null,
+  definition: "select id from public.account_records",
+  columns: [
+    viewColumn("id", "pg_catalog.int4", {
+      schema: "public",
+      table: "account_records",
+      column: "id",
+    }),
+  ],
+  informationSchemaValue: {
+    table_schema: "api",
+    table_name: "account_records",
+  },
+} as any;
+
+/**
+ * `select secret from account_records` -- unqualified, so the source is
+ * recorded against this view's own schema and points at the curated
+ * `api.account_records`, which does not carry `secret`.
+ */
+export const apiSecrets: ViewDetails = {
+  name: "account_secrets",
+  schemaName: "api",
+  kind: "view",
+  comment: null,
+  definition: "select secret from account_records",
+  columns: [
+    {
+      ...viewColumn("secret", "pg_catalog.text", {
+        schema: "api",
+        table: "account_records",
+        column: "secret",
+      }),
+      /* Only resolving through to the table's nullable `secret` makes this null. */
+      isNullable: false,
+    },
+  ],
+  informationSchemaValue: {
+    table_schema: "api",
+    table_name: "account_secrets",
+  },
+} as any;
+
+const crossSchemaViews: Record<string, Schema> = {
+  public: {
+    ...emptySchema,
+    name: "public",
+    tables: [accountRecords],
+    views: [publicAccounts],
+  },
+  api: {
+    ...emptySchema,
+    name: "api",
+    views: [apiAccounts, apiAccountsDetails, apiRecords, apiSecrets],
+  },
+};
+
+export default crossSchemaViews;


### PR DESCRIPTION
### Bug

A view column's source is matched to candidate relations **by name alone**, so a view is treated as a self-reference whenever it shares a name with what it selects from:

```sql
create view api.accounts as select * from public.accounts;
```

Every `accounts` candidate gets discarded, and kanel warns `Could not resolve source` and emits `unknown`.

Separately, nullability only looked at **tables in the source schema**, so a view over a view never inherited it and columns silently came out non-nullable — the worse of the two, since an `unknown` is visible in review and a wrong `NOT NULL` isn't.

### Fix

Both call sites walked the schema graph themselves. That traversal moves into `resolveViewSource.ts`:

- **`hasSource`** — narrows to a traced column; lets both call sites drop their casts (−5 in `resolveType`)
- **`findSourceRelation`** — a relation is *itself* only when schema **and** name match, and a candidate must actually carry the column
- **`findOriginColumn`** — follows the chain through nested views; returns `undefined` on a broken chain or cycle rather than a half-resolved answer

Also removes a latent crash: `schemas[source.schema]` was indexed unguarded.

**Why the column check:** Postgres drops the schema qualifier when rendering a view definition if the relation is on the `search_path`, so `from public.accounts` comes back as `from accounts`. `extractView` re-parses that with the *view's own* schema as the default, so it reads as `api`. Harmless until `api.accounts` exists — exactly the wrapper pattern — and wrappers often omit the referenced column.
